### PR TITLE
Fix docker build by specify the device.

### DIFF
--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -144,6 +144,7 @@
 									<name>libertybans-build</name>
 									<opts>
 										<type>tmpfs</type>
+										<device>tmpfs</device>
 									</opts>									
 								</volume>
 							</volumes>


### PR DESCRIPTION
This very small change fixes the build of the docker-volume branch, by specifying the device, which is required by the [docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin).