### PR TITLE
Add some new variables

### DIFF
--- a/bans-api/src/main/java/space/arim/libertybans/api/formatter/PunishmentFormatter.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/formatter/PunishmentFormatter.java
@@ -41,6 +41,14 @@ public interface PunishmentFormatter {
 	String formatPunishmentType(PunishmentType type);
 
 	/**
+	 * Formats a punishment type as a verb according to the configuration
+	 *
+	 * @param type the punishment type to format
+	 * @return the formatted string
+	 */
+	String formatPunishmentTypeVerb(PunishmentType type);
+
+	/**
 	 * Gets the configured timezone
 	 * 
 	 * @return the zone id used for displaying dates

--- a/bans-core/src/main/java/space/arim/libertybans/core/commands/ListCommands.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/commands/ListCommands.java
@@ -216,11 +216,14 @@ public class ListCommands extends AbstractSubCommandGroup {
 
 			String pageString = Integer.toString(page);
 			String nextPageString = Integer.toString(page + 1);
+			String previousPageString = Integer.toString(page - 1);
 			class HeaderFooterReplacer implements UnaryOperator<String> {
 				@Override
 				public String apply(String str) {
 					str = str.replace("%PAGE%", pageString)
-							.replace("%NEXTPAGE%", nextPageString);
+							.replace("%NEXTPAGE%", nextPageString)
+							.replace("%PREVIOUSPAGE%", previousPageString)
+							.replace("%PREVPAGE%", previousPageString);
 					return replaceTargetIn(str);
 				}
 			}

--- a/bans-core/src/main/java/space/arim/libertybans/core/commands/ListCommands.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/commands/ListCommands.java
@@ -222,8 +222,7 @@ public class ListCommands extends AbstractSubCommandGroup {
 				public String apply(String str) {
 					str = str.replace("%PAGE%", pageString)
 							.replace("%NEXTPAGE%", nextPageString)
-							.replace("%PREVIOUSPAGE%", previousPageString)
-							.replace("%PREVPAGE%", previousPageString);
+							.replace("%PREVIOUSPAGE%", previousPageString);
 					return replaceTargetIn(str);
 				}
 			}

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
@@ -138,6 +138,7 @@ public class Formatter implements InternalFormatter {
 	private enum SimpleReplaceable {
 		ID,
 		TYPE,
+		TYPE_VERB,
 		VICTIM_ID,
 		OPERATOR_ID,
 		UNOPERATOR_ID,
@@ -146,8 +147,11 @@ public class Formatter implements InternalFormatter {
 		DURATION,
 		START_DATE,
 		TIME_PASSED,
+		TIME_PASSED_SIMPLE,
 		END_DATE,
-		TIME_REMAINING;
+		TIME_REMAINING,
+		TIME_REMAINING_SIMPLE,
+		IS_ACTIVE;
 		
 		String getVariable() {
 			return "%" + name() + "%";
@@ -172,14 +176,17 @@ public class Formatter implements InternalFormatter {
 
 		final long timePassed = now - start;
 
-		final String durationFormatted;
-		final String relativeEndFormatted;
+		final String durationFormatted, durationFormattedSimple;
+		final String relativeEndFormatted, relativeEndFormattedSimple;
+		boolean isActive = false;
 
 		if (punishment.isPermanent()) {
 			// Permanent punishment
 			MessagesConfig.Formatting.PermanentDisplay display = messages().formatting().permanentDisplay();
 			durationFormatted = display.duration();
 			relativeEndFormatted = display.relative();
+			relativeEndFormattedSimple = relativeEndFormatted;
+			isActive = true;
 
 		} else {
 			final long end = punishment.getEndDateSeconds();
@@ -187,25 +194,32 @@ public class Formatter implements InternalFormatter {
 			// Temporary punishment
 			long duration = end - start;
 			durationFormatted = formatRelative(duration);
+			durationFormattedSimple = formatRelativeSimple(duration);
 
 			if (timePassed < MARGIN_OF_INITIATION) {
 				// Punishment recently enacted
 				// Using a margin of initiation prevents the "29 days, 23 hours, 59 minutes" issue
 				relativeEndFormatted = durationFormatted;
+				relativeEndFormattedSimple = durationFormattedSimple;
+				isActive = true;
 
 			} else if (timePassed >= duration) {
 				// Expired punishment
 				relativeEndFormatted = messages().formatting().noTimeRemainingDisplay();
+				relativeEndFormattedSimple = relativeEndFormatted;
 			} else {
 				// Punishment still active
 				long timeRemaining = end - now;
 				relativeEndFormatted = formatRelative(timeRemaining);
+				relativeEndFormattedSimple = formatRelativeSimple(timeRemaining);
+				isActive = true;
 			}
 		}
 
 		Map<SimpleReplaceable, String> simpleReplacements = new EnumMap<>(SimpleReplaceable.class);
 		simpleReplacements.put(SimpleReplaceable.ID, Long.toString(punishment.getIdentifier()));
 		simpleReplacements.put(SimpleReplaceable.TYPE, formatPunishmentType(punishment.getType()));
+		simpleReplacements.put(SimpleReplaceable.TYPE_VERB, formatPunishmentTypeVerb(punishment.getType()));
 		simpleReplacements.put(SimpleReplaceable.VICTIM_ID, formatVictimId(punishment.getVictim()));
 		simpleReplacements.put(SimpleReplaceable.OPERATOR_ID, formatOperatorId(punishment.getOperator()));
 		if (unOperator != null)
@@ -215,12 +229,16 @@ public class Formatter implements InternalFormatter {
 		simpleReplacements.put(SimpleReplaceable.DURATION, durationFormatted);
 		simpleReplacements.put(SimpleReplaceable.START_DATE, formatAbsoluteDate(punishment.getStartDate()));
 		simpleReplacements.put(SimpleReplaceable.TIME_PASSED, formatRelative(timePassed));
+		simpleReplacements.put(SimpleReplaceable.TIME_PASSED_SIMPLE, formatRelativeSimple(timePassed));
 		simpleReplacements.put(SimpleReplaceable.END_DATE, formatAbsoluteDate(punishment.getEndDate()));
 		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING, relativeEndFormatted);
+		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING_SIMPLE, relativeEndFormattedSimple);
+		MessagesConfig.Formatting.PunishmentActiveDisplay display = messages().formatting().punishmentActiveDisplay();
+		simpleReplacements.put(SimpleReplaceable.IS_ACTIVE, (display != null) ? ((isActive) ? display.active() : display.expired()) : "Unknown");
 
 		return simpleReplacements;
 	}
-	
+
 	private CentralisedFuture<Component> formatWithPunishment0(ComponentText componentText,
 															   Map<SimpleReplaceable, String> simpleReplacements,
 															   Map<FutureReplaceable, CentralisedFuture<String>> futureReplacements) {
@@ -355,11 +373,43 @@ public class Formatter implements InternalFormatter {
 		}
 		return joiner.toString();
 	}
+
+	String formatRelativeSimple(long diff) {
+		if (diff < 0) {
+			return formatRelativeSimple(-diff);
+		}
+		MessagesConfig.Misc.Time timeConfig = messages().misc().time();
+
+		List<Map.Entry<ChronoUnit, String>> fragments = new ArrayList<>(timeConfig.fragments().entrySet());
+		fragments.sort(Map.Entry.<ChronoUnit, String>comparingByKey().reversed());
+		String segment = "";
+
+		for (Map.Entry<ChronoUnit, String> fragment : fragments) {
+			long unitLength = fragment.getKey().getDuration().toSeconds();
+			if (diff >= unitLength) {
+				long amount = Math.round(diff / (double) unitLength);
+				if (amount > 0) {
+					segment = fragment.getValue().replace("%VALUE%", Long.toString(amount));
+					break;
+				}
+			}
+		}
+		if (segment.isEmpty()) {
+			return timeConfig.fallbackSeconds().replace("%VALUE%", Long.toString(diff));
+		}
+		return segment;
+	}
 	
 	@Override
 	public String formatPunishmentType(PunishmentType type) {
 		String formatted = messages().formatting().punishmentTypeDisplay().get(type);
 		return (formatted == null) ? type.toString() : formatted;
+	}
+
+	@Override
+	public String formatPunishmentTypeVerb(PunishmentType type) {
+		String formatted = messages().formatting().punishmentTypeVerbDisplay().get(type);
+		return (formatted == null) ? type.toString() + "ed" : formatted;
 	}
 
 	@Override

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
@@ -232,8 +232,8 @@ public class Formatter implements InternalFormatter {
 		simpleReplacements.put(SimpleReplaceable.END_DATE, formatAbsoluteDate(punishment.getEndDate()));
 		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING, relativeEndFormatted);
 		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING_SIMPLE, relativeEndFormattedSimple);
-		MessagesConfig.Formatting.PunishmentExpiredDisplay display = messages().formatting().punishmentActiveDisplay();
-		simpleReplacements.put(SimpleReplaceable.HAS_EXPIRED, (display != null) ? ((notExpired) ? display.notExpired() : display.expired()) : "Unknown"); // null check needed for tests
+		MessagesConfig.Formatting.PunishmentExpiredDisplay display = messages().formatting().punishmentExpiredDisplay();
+		simpleReplacements.put(SimpleReplaceable.HAS_EXPIRED, (notExpired) ? display.notExpired() : display.expired());
 
 		return simpleReplacements;
 	}

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/Formatter.java
@@ -151,7 +151,7 @@ public class Formatter implements InternalFormatter {
 		END_DATE,
 		TIME_REMAINING,
 		TIME_REMAINING_SIMPLE,
-		IS_ACTIVE;
+		HAS_EXPIRED;
 		
 		String getVariable() {
 			return "%" + name() + "%";
@@ -176,9 +176,9 @@ public class Formatter implements InternalFormatter {
 
 		final long timePassed = now - start;
 
-		final String durationFormatted, durationFormattedSimple;
+		final String durationFormatted;
 		final String relativeEndFormatted, relativeEndFormattedSimple;
-		boolean isActive = false;
+		boolean notExpired = false;
 
 		if (punishment.isPermanent()) {
 			// Permanent punishment
@@ -186,7 +186,7 @@ public class Formatter implements InternalFormatter {
 			durationFormatted = display.duration();
 			relativeEndFormatted = display.relative();
 			relativeEndFormattedSimple = relativeEndFormatted;
-			isActive = true;
+			notExpired = true;
 
 		} else {
 			final long end = punishment.getEndDateSeconds();
@@ -194,14 +194,13 @@ public class Formatter implements InternalFormatter {
 			// Temporary punishment
 			long duration = end - start;
 			durationFormatted = formatRelative(duration);
-			durationFormattedSimple = formatRelativeSimple(duration);
 
 			if (timePassed < MARGIN_OF_INITIATION) {
 				// Punishment recently enacted
 				// Using a margin of initiation prevents the "29 days, 23 hours, 59 minutes" issue
 				relativeEndFormatted = durationFormatted;
-				relativeEndFormattedSimple = durationFormattedSimple;
-				isActive = true;
+				relativeEndFormattedSimple = formatRelativeSimple(duration);
+				notExpired = true;
 
 			} else if (timePassed >= duration) {
 				// Expired punishment
@@ -212,7 +211,7 @@ public class Formatter implements InternalFormatter {
 				long timeRemaining = end - now;
 				relativeEndFormatted = formatRelative(timeRemaining);
 				relativeEndFormattedSimple = formatRelativeSimple(timeRemaining);
-				isActive = true;
+				notExpired = true;
 			}
 		}
 
@@ -233,8 +232,8 @@ public class Formatter implements InternalFormatter {
 		simpleReplacements.put(SimpleReplaceable.END_DATE, formatAbsoluteDate(punishment.getEndDate()));
 		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING, relativeEndFormatted);
 		simpleReplacements.put(SimpleReplaceable.TIME_REMAINING_SIMPLE, relativeEndFormattedSimple);
-		MessagesConfig.Formatting.PunishmentActiveDisplay display = messages().formatting().punishmentActiveDisplay();
-		simpleReplacements.put(SimpleReplaceable.IS_ACTIVE, (display != null) ? ((isActive) ? display.active() : display.expired()) : "Unknown");
+		MessagesConfig.Formatting.PunishmentExpiredDisplay display = messages().formatting().punishmentActiveDisplay();
+		simpleReplacements.put(SimpleReplaceable.HAS_EXPIRED, (display != null) ? ((notExpired) ? display.notExpired() : display.expired()) : "Unknown"); // null check needed for tests
 
 		return simpleReplacements;
 	}

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/InternalFormatter.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/InternalFormatter.java
@@ -21,7 +21,6 @@ package space.arim.libertybans.core.config;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import space.arim.api.jsonchat.adventure.util.ComponentText;
-import space.arim.libertybans.api.PunishmentType;
 import space.arim.omnibus.util.concurrent.CentralisedFuture;
 
 import space.arim.libertybans.api.Operator;

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/InternalFormatter.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/InternalFormatter.java
@@ -21,6 +21,7 @@ package space.arim.libertybans.core.config;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import space.arim.api.jsonchat.adventure.util.ComponentText;
+import space.arim.libertybans.api.PunishmentType;
 import space.arim.omnibus.util.concurrent.CentralisedFuture;
 
 import space.arim.libertybans.api.Operator;

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
@@ -51,6 +51,7 @@ import space.arim.libertybans.core.alts.AltsSection;
 		"",
 		"%ID% - punishment ID number",
 		"%TYPE% - punishment type, e.g. 'Ban'",
+		"%TYPE_VERB% - punishment type as a verb, e.g. 'Banned'",
 		"%VICTIM% - display name of the victim of the punishment",
 		"%VICTIM_ID% - internal identifier of victim",
 		"%OPERATOR% - display name of the staff member who made the punishment",
@@ -62,11 +63,16 @@ import space.arim.libertybans.core.alts.AltsSection;
 		"%DURATION% - original duration (how long the punishment was made for)",
 		"%START_DATE% - the date the punishment was created",
 		"%TIME_PASSED% - the time since the punishment was created",
+		"%TIME_PASSED_SIMPLE% - the time since the punishment was created, rounded to the biggest time unit possible (e.g. 2 months instead of 1 month 23 days)",
 		"%END_DATE% - the date the punishment will end, or formatting.permanent-display.absolute for permanent punishments",
 		"%TIME_REMAINING% - the time until the punishment ends, or formatting.permanent-display.relative for permanent punishments",
+		"%TIME_REMAINING_SIMPLE% - the time until the punishment ends, rounded to the biggest time unit possible (e.g. 10 days instead of 9 days 13 hours)",
+		"%HAS_EXPIRED% - Shows if a punishments duration has run out. Does not check if the punishment is revoked!",
 		"",
 		"The following variables have limited availability:",
 		"%TARGET% - the original target argument of a command. For example, in '/ipban Player1', %TARGET% is Player1",
+		"%NEXTPAGE% - the number of the next page of a list like history",
+		"%PREVIOUSPAGE% - the number of the previous page of a list like history",
 		"",
 		""})
 public interface MessagesConfig {
@@ -233,7 +239,7 @@ public interface MessagesConfig {
 		Map<PunishmentType, String> punishmentTypeDisplay();
 
 		@ConfKey("punishment-type-verb-display")
-		@ConfComments("How should punishment types be displayed as a verb?")
+		@ConfComments("How should punishment types be displayed as a verb? Used for the %TYPE_VERB% variable.")
 		@DefaultMap({
 				"ban", "Banned",
 				"mute", "Muted",
@@ -242,18 +248,18 @@ public interface MessagesConfig {
 		})
 		Map<PunishmentType, String> punishmentTypeVerbDisplay();
 
-		@ConfKey("punishment-active-display")
-		@ConfComments("How should the %IS_ACTIVE% variable be displayed?")
+		@ConfKey("punishment-expired-display")
+		@ConfComments("How should the %HAS_EXPIRED% variable be displayed?")
 		@SubSection
-		PunishmentActiveDisplay punishmentActiveDisplay();
+		PunishmentExpiredDisplay punishmentActiveDisplay();
 
-		interface PunishmentActiveDisplay {
+		interface PunishmentExpiredDisplay {
 
-			@ConfComments("How do you describe an active punishments stats?")
-			@DefaultString("Active")
-			String active();
+			@ConfComments("How do you describe a punishment that's not expired?")
+			@DefaultString("Not expired")
+			String notExpired();
 
-			@ConfComments("How do you describe an expired punishments state?")
+			@ConfComments("How do you describe an expired punishment?")
 			@DefaultString("Expired")
 			String expired();
 

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
@@ -251,7 +251,7 @@ public interface MessagesConfig {
 		@ConfKey("punishment-expired-display")
 		@ConfComments("How should the %HAS_EXPIRED% variable be displayed?")
 		@SubSection
-		PunishmentExpiredDisplay punishmentActiveDisplay();
+		PunishmentExpiredDisplay punishmentExpiredDisplay();
 
 		interface PunishmentExpiredDisplay {
 

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
@@ -232,6 +232,33 @@ public interface MessagesConfig {
 		})
 		Map<PunishmentType, String> punishmentTypeDisplay();
 
+		@ConfKey("punishment-type-verb-display")
+		@ConfComments("How should punishment types be displayed as a verb?")
+		@DefaultMap({
+				"ban", "Banned",
+				"mute", "Muted",
+				"warn", "Warned",
+				"kick", "Kicked"
+		})
+		Map<PunishmentType, String> punishmentTypeVerbDisplay();
+
+		@ConfKey("punishment-active-display")
+		@ConfComments("How should the %IS_ACTIVE% variable be displayed?")
+		@SubSection
+		PunishmentActiveDisplay punishmentActiveDisplay();
+
+		interface PunishmentActiveDisplay {
+
+			@ConfComments("How do you describe an active punishments stats?")
+			@DefaultString("Active")
+			String active();
+
+			@ConfComments("How do you describe an expired punishments state?")
+			@DefaultString("Expired")
+			String expired();
+
+		}
+
 	}
 	
 	@SubSection

--- a/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/MessagesConfig.java
@@ -255,7 +255,8 @@ public interface MessagesConfig {
 
 		interface PunishmentExpiredDisplay {
 
-			@ConfComments("How do you describe a punishment that's not expired?")
+			@ConfKey("not-expired")
+			@ConfComments("How do you describe a punishment which is not expired?")
 			@DefaultString("Not expired")
 			String notExpired();
 

--- a/bans-core/src/main/resources/contributors
+++ b/bans-core/src/main/resources/contributors
@@ -6,6 +6,7 @@ D3adhkwen
 FranMC23
 gepron1x
 Simon (KoxSosen)
+Gamer153
 
 AGI
 BumbleTree

--- a/bans-core/src/test/java/space/arim/libertybans/core/config/FormatterTest.java
+++ b/bans-core/src/test/java/space/arim/libertybans/core/config/FormatterTest.java
@@ -173,6 +173,10 @@ public class FormatterTest {
 		lenient().when(formatting.globalScopeDisplay()).thenReturn("global");
 		lenient().when(formatting.punishmentTypeDisplay()).thenReturn(Map.of());
 		lenient().when(formatting.noTimeRemainingDisplay()).thenReturn("(No time remaining)");
+		MessagesConfig.Formatting.PunishmentExpiredDisplay expiredDisplay = mock(MessagesConfig.Formatting.PunishmentExpiredDisplay.class);
+		lenient().when(expiredDisplay.notExpired()).thenReturn("not expired");
+		lenient().when(expiredDisplay.expired()).thenReturn("expired");
+		lenient().when(formatting.punishmentExpiredDisplay()).thenReturn(expiredDisplay);
 	}
 
 	private void setupSimpleDefaults() {

--- a/bans-core/src/test/java/space/arim/libertybans/core/config/FormatterTest.java
+++ b/bans-core/src/test/java/space/arim/libertybans/core/config/FormatterTest.java
@@ -142,6 +142,20 @@ public class FormatterTest {
 				formatter.formatRelative(ChronoUnit.YEARS.getDuration().multipliedBy(3).getSeconds()));
 	}
 
+	@Test
+	public void formatRelativeSimple() {
+		setTimeConf(simpleTimeConf());
+
+		assertEquals("3 minutes",
+				formatter.formatRelativeSimple(3L * 60L + 5L));
+		assertEquals("5 hours",
+				formatter.formatRelativeSimple(4L * 60L * 60L + 45L * 60L + 58L));
+		assertEquals("2 days",
+				formatter.formatRelativeSimple(2L * 24L * 60L * 60L + 25L * 60L + 40L));
+		assertEquals("153 years",
+				formatter.formatRelativeSimple(ChronoUnit.YEARS.getDuration().multipliedBy(153).getSeconds()));
+	}
+
 	private void setSimpleDateFormatting() {
 		MainConfig mainConfig = mock(MainConfig.class);
 		MainConfig.DateFormatting dateFormatting = mock(MainConfig.DateFormatting.class);


### PR DESCRIPTION
`%PREVIOUSPAGE%` or `%PREVPAGE%` - There is currently a `%NEXTPAGE%` variable which can grab the next page of history (assuming it does currentpage + 1) but there was no previous page variable.

`%TIME_PASSED_SIMPLE%`: Currently, the `%TIME_PASSED%` variable displays very specific (example: 6 months, 3 weeks, 6 days, 14 hours, 12 seconds) so this is just a simpler version (example: 7 months. Rounded up from 6 months, 3 weeks, 6 days)

`%TIME_REMAINING_SIMPLE%`: The same as `%TIME_PASSED_SIMPLE%`, but for `%TIME_REMAINING%`

`%TYPE_VERB%` - Currently `%TYPE%` exists which outputs Ban, Warn, Mute, Kick, but this variable outputs Banned, Warned, Muted, Kicked instead. (configurable)

`%IS_ACTIVE%` Is this punishment active? Check if ban/mute has remaining time, or if warn or kick has been revoked. Returns a configurable output depending on if the punishment is active or expired.