### PR TITLE
Update H2 to 2.0.206.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- Testing dependencies -->
 		<junit.version>5.8.2</junit.version>
 		<mockito.version>4.2.0</mockito.version>
-		<h2.version>1.4.199</h2.version>
+		<h2.version>2.0.206</h2.version>
 
 		<!-- API dependencies -->
 		<omnibus.version>1.1.0-RC2</omnibus.version>


### PR DESCRIPTION
Fixes a [critical security issue](https://github.com/h2database/h2database/security/advisories/GHSA-h376-j262-vhq6) with the H2 console.