### PR TITLE
Build system enhancements

### DIFF
--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -259,6 +259,7 @@
 							<containerNamePattern>%a</containerNamePattern>
 							<showLogs>true</showLogs>
 							<startParallel>true</startParallel>
+							<removeVolumes>true</removeVolumes>
 							<images>
 								<image>
 									<name>mariadb:10.3</name>
@@ -372,6 +373,7 @@
 										<cmd>start-single-node --insecure</cmd>
 										<hostname>cockroach</hostname>
 										<ports>
+											<!--suppress UnresolvedMavenProperty -->
 											<port>127.0.0.1:${it.cockroachdb.port}:26257</port>
 										</ports>
 										<wait>

--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -254,7 +254,7 @@
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
-						<version>0.37.0</version>
+						<version>0.38.1</version>
 						<configuration>
 							<containerNamePattern>%a</containerNamePattern>
 							<showLogs>true</showLogs>

--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -277,7 +277,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-mariadb-legacy:/var/lib/mysql</volume>
 											</bind>
 										</volumes>
 									</run>
@@ -298,7 +298,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-mariadb-modern:/var/lib/mysql</volume>
 											</bind>
 										</volumes>
 									</run>
@@ -319,7 +319,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-mysql:/var/lib/mysql</volume>
 											</bind>
 										</volumes>
 									</run>
@@ -340,7 +340,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-postgresql-legacy:/var/lib/postgresql/data</volume>
 											</bind>
 										</volumes>
 									</run>
@@ -361,7 +361,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-postgresql-modern:/var/lib/postgresql/data</volume>
 											</bind>
 										</volumes>
 									</run>
@@ -373,7 +373,6 @@
 										<cmd>start-single-node --insecure</cmd>
 										<hostname>cockroach</hostname>
 										<ports>
-											<!--suppress UnresolvedMavenProperty -->
 											<port>127.0.0.1:${it.cockroachdb.port}:26257</port>
 										</ports>
 										<wait>
@@ -381,15 +380,56 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build</volume>
+												<volume>libertybans-build-cockroachdb:/cockroach</volume>
 											</bind>
 										</volumes>
 									</run>
 								</image>
 							</images>
 							<volumes>
+								<!-- MariaDB Legacy container volume -->
 								<volume>
-									<name>libertybans-build</name>
+									<name>libertybans-build-mariadb-legacy</name>
+									<opts>
+										<type>tmpfs</type>
+										<device>tmpfs</device>
+									</opts>
+								</volume>
+								<!-- MariaDB Modern container volume -->
+								<volume>
+									<name>libertybans-build-mariadb-modern</name>
+									<opts>
+										<type>tmpfs</type>
+										<device>tmpfs</device>
+									</opts>
+								</volume>
+								<!-- MySQL container volume -->
+								<volume>
+									<name>libertybans-build-mysql</name>
+									<opts>
+										<type>tmpfs</type>
+										<device>tmpfs</device>
+									</opts>
+								</volume>
+								<!-- Postgresql Legacy container volume -->
+								<volume>
+									<name>libertybans-build-postgresql-legacy</name>
+									<opts>
+										<type>tmpfs</type>
+										<device>tmpfs</device>
+									</opts>
+								</volume>
+								<!-- Postgresql Modern container volume -->
+								<volume>
+									<name>libertybans-build-postgresql-modern</name>
+									<opts>
+										<type>tmpfs</type>
+										<device>tmpfs</device>
+									</opts>
+								</volume>
+								<!-- Cockroachdb container volume -->
+								<volume>
+									<name>libertybans-build-cockroachdb</name>
 									<opts>
 										<type>tmpfs</type>
 										<device>tmpfs</device>

--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -380,7 +380,7 @@
 										</wait>
 										<volumes>
 											<bind>
-												<volume>libertybans-build-cockroachdb:/cockroach</volume>
+												<volume>libertybans-build-cockroachdb:/usr/local/lib/cockroach</volume>
 											</bind>
 										</volumes>
 									</run>


### PR DESCRIPTION
- Addresses the Docker container volume leak which was previusly fixed with adding the `-Ddocker.removeVolumes` flag. Now this is unnececarry.
- Makes it, so the build creates a different volume for each container. Using the same volume for all containers isn't a good pratice.
- Updates the `docker-maven-plugin` to `v0.38.1 (2021-12-18)`.