### PR TITLE
CheckUser Addon

### DIFF
--- a/bans-core-addons/addon-integration/pom.xml
+++ b/bans-core-addons/addon-integration/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>addon-warn-actions</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>space.arim.libertybans</groupId>
+            <artifactId>addon-command-checkuser</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/bans-core-addons/addon-integration/src/test/java/space/arim/libertybans/core/addon/it/ServiceLoadingIT.java
+++ b/bans-core-addons/addon-integration/src/test/java/space/arim/libertybans/core/addon/it/ServiceLoadingIT.java
@@ -22,6 +22,7 @@ package space.arim.libertybans.core.addon.it;
 import org.junit.jupiter.api.Test;
 import space.arim.libertybans.core.addon.AddonLoader;
 import space.arim.libertybans.core.addon.checkpunish.CheckPunishModule;
+import space.arim.libertybans.core.addon.checkuser.CheckUserModule;
 import space.arim.libertybans.core.addon.staffrollback.StaffRollbackModule;
 import space.arim.libertybans.core.addon.warnactions.WarnActionsModule;
 
@@ -35,7 +36,10 @@ public class ServiceLoadingIT {
 	@Test
 	public void loadAddons() {
 		assertEquals(
-				Set.of(new CheckPunishModule(), new StaffRollbackModule(), new WarnActionsModule()),
+				Set.of(
+						new CheckPunishModule(), new CheckUserModule(),
+						new StaffRollbackModule(), new WarnActionsModule()
+				),
 				assertDoesNotThrow(AddonLoader::loadAddonBindModules)
 		);
 	}

--- a/bans-core-addons/command-checkuser/pom.xml
+++ b/bans-core-addons/command-checkuser/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>space.arim.libertybans</groupId>
+        <artifactId>bans-core-addons</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>command-checkuser</name>
+    <artifactId>addon-command-checkuser</artifactId>
+</project>

--- a/bans-core-addons/command-checkuser/src/main/java/module-info.java
+++ b/bans-core-addons/command-checkuser/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+import space.arim.libertybans.core.addon.AddonProvider;
+import space.arim.libertybans.core.addon.checkuser.CheckUserProvider;
+
+module space.arim.libertybans.core.addon.checkuser {
+    requires jakarta.inject;
+    requires net.kyori.adventure;
+    requires net.kyori.examination.api;
+    requires static org.jetbrains.annotations;
+    requires space.arim.api.jsonchat;
+    requires space.arim.dazzleconf;
+    requires space.arim.injector;
+    requires space.arim.libertybans.core;
+    exports space.arim.libertybans.core.addon.checkuser;
+    provides AddonProvider with CheckUserProvider;
+}

--- a/bans-core-addons/command-checkuser/src/main/java/module-info.java
+++ b/bans-core-addons/command-checkuser/src/main/java/module-info.java
@@ -2,14 +2,14 @@ import space.arim.libertybans.core.addon.AddonProvider;
 import space.arim.libertybans.core.addon.checkuser.CheckUserProvider;
 
 module space.arim.libertybans.core.addon.checkuser {
-    requires jakarta.inject;
-    requires net.kyori.adventure;
-    requires net.kyori.examination.api;
-    requires static org.jetbrains.annotations;
-    requires space.arim.api.jsonchat;
-    requires space.arim.dazzleconf;
-    requires space.arim.injector;
-    requires space.arim.libertybans.core;
-    exports space.arim.libertybans.core.addon.checkuser;
-    provides AddonProvider with CheckUserProvider;
+	requires jakarta.inject;
+	requires net.kyori.adventure;
+	requires net.kyori.examination.api;
+	requires static org.jetbrains.annotations;
+	requires space.arim.api.jsonchat;
+	requires space.arim.dazzleconf;
+	requires space.arim.injector;
+	requires space.arim.libertybans.core;
+	exports space.arim.libertybans.core.addon.checkuser;
+	provides AddonProvider with CheckUserProvider;
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserAddon.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserAddon.java
@@ -1,33 +1,35 @@
 package space.arim.libertybans.core.addon.checkuser;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import space.arim.libertybans.core.addon.AbstractAddon;
 import space.arim.libertybans.core.addon.AddonCenter;
 
+@Singleton
 public final class CheckUserAddon extends AbstractAddon<CheckUserConfig> {
 
-    @Inject
-    public CheckUserAddon(AddonCenter addonCenter) {
-        super(addonCenter);
-    }
+	@Inject
+	public CheckUserAddon(AddonCenter addonCenter) {
+		super(addonCenter);
+	}
 
-    @Override
-    public void startup() {
+	@Override
+	public void startup() {
 
-    }
+	}
 
-    @Override
-    public void shutdown() {
+	@Override
+	public void shutdown() {
 
-    }
+	}
 
-    @Override
-    public Class<CheckUserConfig> configInterface() {
-        return CheckUserConfig.class;
-    }
+	@Override
+	public Class<CheckUserConfig> configInterface() {
+		return CheckUserConfig.class;
+	}
 
-    @Override
-    public String identifier() {
-        return "command-checkuser";
-    }
+	@Override
+	public String identifier() {
+		return "command-checkuser";
+	}
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserAddon.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserAddon.java
@@ -1,0 +1,33 @@
+package space.arim.libertybans.core.addon.checkuser;
+
+import jakarta.inject.Inject;
+import space.arim.libertybans.core.addon.AbstractAddon;
+import space.arim.libertybans.core.addon.AddonCenter;
+
+public final class CheckUserAddon extends AbstractAddon<CheckUserConfig> {
+
+    @Inject
+    public CheckUserAddon(AddonCenter addonCenter) {
+        super(addonCenter);
+    }
+
+    @Override
+    public void startup() {
+
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public Class<CheckUserConfig> configInterface() {
+        return CheckUserConfig.class;
+    }
+
+    @Override
+    public String identifier() {
+        return "command-checkuser";
+    }
+}

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -1,0 +1,101 @@
+package space.arim.libertybans.core.addon.checkuser;
+
+import jakarta.inject.Inject;
+import org.jetbrains.annotations.Nullable;
+import space.arim.libertybans.api.PunishmentType;
+import space.arim.libertybans.api.punish.Punishment;
+import space.arim.libertybans.api.select.PunishmentSelector;
+import space.arim.libertybans.core.commands.AbstractCommandExecution;
+import space.arim.libertybans.core.commands.AbstractSubCommandGroup;
+import space.arim.libertybans.core.commands.CommandExecution;
+import space.arim.libertybans.core.commands.CommandPackage;
+import space.arim.libertybans.core.config.InternalFormatter;
+import space.arim.libertybans.core.env.CmdSender;
+import space.arim.libertybans.core.env.UUIDAndAddress;
+import space.arim.libertybans.core.uuid.UUIDManager;
+import space.arim.omnibus.util.concurrent.ReactionStage;
+
+import java.util.stream.Stream;
+
+public final class CheckUserCommand extends AbstractSubCommandGroup {
+
+    private final PunishmentSelector selector;
+    private final UUIDManager uuidManager;
+    private final InternalFormatter formatter;
+    private final CheckUserAddon checkUserAddon;
+
+    @Inject
+    public CheckUserCommand(Dependencies dependencies,
+                            PunishmentSelector selector, UUIDManager uuidManager, InternalFormatter internalFormatter, CheckUserAddon checkUserAddon) {
+        super(dependencies, "checkuser");
+        this.selector = selector;
+        this.uuidManager = uuidManager;
+        this.formatter = internalFormatter;
+        this.checkUserAddon = checkUserAddon;
+    }
+
+    @Override
+    public CommandExecution execute(CmdSender sender, CommandPackage command, String arg) {
+        return new Execution(sender, command);
+    }
+
+    @Override
+    public Stream<String> suggest(CmdSender sender, String arg, int argIndex) {
+        return Stream.empty();
+    }
+
+    @Override
+    public boolean hasTabCompletePermission(CmdSender sender, String arg) {
+        return hasPermission(sender);
+    }
+
+    private boolean hasPermission(CmdSender sender) {
+        return sender.hasPermission("libertybans.addon.checkuser.use");
+    }
+
+    private final class Execution extends AbstractCommandExecution {
+
+        private final CheckUserConfig config;
+
+        private Execution(CmdSender sender, CommandPackage command) {
+            super(sender, command);
+            config = checkUserAddon.config();
+        }
+
+        @Override
+        public @Nullable ReactionStage<Void> execute() {
+            if (!hasPermission(sender())) {
+                sender().sendMessage(config.noPermission());
+                return null;
+            }
+
+            if (!command().hasNext()) {
+                sender().sendMessage(config.usage());
+                return null;
+            }
+
+            String name = command().next();
+
+            return uuidManager.lookupPlayer(name)
+                    .thenCompose(optUuid -> {
+                        if (optUuid.isEmpty()) {
+                            sender().sendMessage(config.doesNotExist());
+                            return completedFuture(null);
+                        }
+
+                        UUIDAndAddress uuid = optUuid.get();
+                        return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.BAN)
+                                .thenCompose(optPunishment -> {
+                                    if (optPunishment.isEmpty()) {
+                                        sender().sendMessage(config.noPunishment());
+                                        return completedFuture(null);
+                                    }
+                                    Punishment punishment = optPunishment.get();
+
+                                    return formatter.formatWithPunishment(config.layout(), punishment)
+                                            .thenAccept(sender()::sendMessage);
+                                });
+                    });
+        }
+    }
+}

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -74,8 +74,6 @@ public final class CheckUserCommand extends AbstractSubCommandGroup {
                 return null;
             }
 
-            String type = command().next();
-
             String name = command().next();
 
             return uuidManager.lookupPlayer(name)

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -100,7 +100,7 @@ public final class CheckUserCommand extends AbstractSubCommandGroup {
                                                     return formatter.formatWithPunishment(config.layout(), punishment)
                                                             .thenAccept(sender()::sendMessage);
                                                 });
-                                        }
+                                    }
                                     Punishment punishment = optPunishment.get();
 
                                     return formatter.formatWithPunishment(config.layout(), punishment)

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -19,92 +19,93 @@ import java.util.stream.Stream;
 
 public final class CheckUserCommand extends AbstractSubCommandGroup {
 
-    private final PunishmentSelector selector;
-    private final UUIDManager uuidManager;
-    private final InternalFormatter formatter;
-    private final CheckUserAddon checkUserAddon;
+	private final PunishmentSelector selector;
+	private final UUIDManager uuidManager;
+	private final InternalFormatter formatter;
+	private final CheckUserAddon checkUserAddon;
 
-    @Inject
-    public CheckUserCommand(Dependencies dependencies,
-                            PunishmentSelector selector, UUIDManager uuidManager, InternalFormatter internalFormatter, CheckUserAddon checkUserAddon) {
-        super(dependencies, "checkuser");
-        this.selector = selector;
-        this.uuidManager = uuidManager;
-        this.formatter = internalFormatter;
-        this.checkUserAddon = checkUserAddon;
-    }
+	@Inject
+	public CheckUserCommand(Dependencies dependencies,
+							PunishmentSelector selector, UUIDManager uuidManager, InternalFormatter internalFormatter, CheckUserAddon checkUserAddon) {
+		super(dependencies, "checkuser");
+		this.selector = selector;
+		this.uuidManager = uuidManager;
+		this.formatter = internalFormatter;
+		this.checkUserAddon = checkUserAddon;
+	}
 
-    @Override
-    public CommandExecution execute(CmdSender sender, CommandPackage command, String arg) {
-        return new Execution(sender, command);
-    }
+	@Override
+	public CommandExecution execute(CmdSender sender, CommandPackage command, String arg) {
+		return new Execution(sender, command);
+	}
 
-    @Override
-    public Stream<String> suggest(CmdSender sender, String arg, int argIndex) {
-        return Stream.empty();
-    }
+	@Override
+	public Stream<String> suggest(CmdSender sender, String arg, int argIndex) {
+		return Stream.empty();
+	}
 
-    @Override
-    public boolean hasTabCompletePermission(CmdSender sender, String arg) {
-        return hasPermission(sender);
-    }
+	@Override
+	public boolean hasTabCompletePermission(CmdSender sender, String arg) {
+		return hasPermission(sender);
+	}
 
-    private boolean hasPermission(CmdSender sender) {
-        return sender.hasPermission("libertybans.addon.checkuser.use");
-    }
+	private boolean hasPermission(CmdSender sender) {
+		return sender.hasPermission("libertybans.addon.checkuser.use");
+	}
 
-    private final class Execution extends AbstractCommandExecution {
+	private final class Execution extends AbstractCommandExecution {
 
-        private final CheckUserConfig config;
+		private final CheckUserConfig config;
 
-        private Execution(CmdSender sender, CommandPackage command) {
-            super(sender, command);
-            config = checkUserAddon.config();
-        }
+		private Execution(CmdSender sender, CommandPackage command) {
+			super(sender, command);
+			config = checkUserAddon.config();
+		}
 
-        @Override
-        public @Nullable ReactionStage<Void> execute() {
-            if (!hasPermission(sender())) {
-                sender().sendMessage(config.noPermission());
-                return null;
-            }
+		@Override
+		public @Nullable ReactionStage<Void> execute() {
+			if (!hasPermission(sender())) {
+				sender().sendMessage(config.noPermission());
+				return null;
+			}
 
-            if (!command().hasNext()) {
-                sender().sendMessage(config.usage());
-                return null;
-            }
+			if (!command().hasNext()) {
+				sender().sendMessage(config.usage());
+				return null;
+			}
 
-            String name = command().next();
+			String name = command().next();
 
-            return uuidManager.lookupPlayer(name)
-                    .thenCompose(optUuidAddress -> {
-                        if (optUuidAddress.isEmpty()) {
-                            sender().sendMessage(config.doesNotExist());
-                            return completedFuture(null);
-                        }
+			return uuidManager.lookupPlayer(name).thenCompose(optUuidAddress -> {
+				if (optUuidAddress.isEmpty()) {
+					sender().sendMessage(config.doesNotExist());
+					return completedFuture(null);
+				}
 
-                        UUIDAndAddress uuid = optUuidAddress.get();
-                        return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.BAN)
-                                .thenCompose(optPunishment -> {
-                                    if (optPunishment.isEmpty()) {
-                                        return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.MUTE)
-                                                .thenCompose(optMute -> {
-                                                    if (optMute.isEmpty()) {
-                                                        sender().sendMessage(config.noPunishment());
-                                                        return completedFuture(null);
-                                                    }
-                                                    Punishment punishment = optMute.get();
+				UUIDAndAddress uuidAddress = optUuidAddress.get();
+				return selector.getApplicablePunishment(
+						uuidAddress.uuid(), uuidAddress.address(), PunishmentType.BAN
+				).thenCompose(optPunishment -> {
 
-                                                    return formatter.formatWithPunishment(config.layout(), punishment)
-                                                            .thenAccept(sender()::sendMessage);
-                                                });
-                                    }
-                                    Punishment punishment = optPunishment.get();
+					if (optPunishment.isEmpty()) {
+						return selector.getApplicablePunishment(
+								uuidAddress.uuid(), uuidAddress.address(), PunishmentType.MUTE
+						).thenCompose(optMute -> {
 
-                                    return formatter.formatWithPunishment(config.layout(), punishment)
-                                            .thenAccept(sender()::sendMessage);
-                                });
-                    });
-        }
-    }
+							if (optMute.isEmpty()) {
+								sender().sendMessage(config.noPunishment());
+								return completedFuture(null);
+							}
+							Punishment punishment = optMute.get();
+							return formatter.formatWithPunishment(config.layout(), punishment)
+									.thenAccept(sender()::sendMessage);
+						});
+					}
+					Punishment punishment = optPunishment.get();
+					return formatter.formatWithPunishment(config.layout(), punishment)
+							.thenAccept(sender()::sendMessage);
+				});
+			});
+		}
+	}
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -74,6 +74,8 @@ public final class CheckUserCommand extends AbstractSubCommandGroup {
                 return null;
             }
 
+            String type = command().next();
+
             String name = command().next();
 
             return uuidManager.lookupPlayer(name)
@@ -87,9 +89,18 @@ public final class CheckUserCommand extends AbstractSubCommandGroup {
                         return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.BAN)
                                 .thenCompose(optPunishment -> {
                                     if (optPunishment.isEmpty()) {
-                                        sender().sendMessage(config.noPunishment());
-                                        return completedFuture(null);
-                                    }
+                                        return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.MUTE)
+                                                .thenCompose(optMute -> {
+                                                    if (optMute.isEmpty()) {
+                                                        sender().sendMessage(config.noPunishment());
+                                                        return completedFuture(null);
+                                                    }
+                                                    Punishment punishment = optMute.get();
+
+                                                    return formatter.formatWithPunishment(config.layout(), punishment)
+                                                            .thenAccept(sender()::sendMessage);
+                                                });
+                                        }
                                     Punishment punishment = optPunishment.get();
 
                                     return formatter.formatWithPunishment(config.layout(), punishment)

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserCommand.java
@@ -77,13 +77,13 @@ public final class CheckUserCommand extends AbstractSubCommandGroup {
             String name = command().next();
 
             return uuidManager.lookupPlayer(name)
-                    .thenCompose(optUuid -> {
-                        if (optUuid.isEmpty()) {
+                    .thenCompose(optUuidAddress -> {
+                        if (optUuidAddress.isEmpty()) {
                             sender().sendMessage(config.doesNotExist());
                             return completedFuture(null);
                         }
 
-                        UUIDAndAddress uuid = optUuid.get();
+                        UUIDAndAddress uuid = optUuidAddress.get();
                         return selector.getApplicablePunishment(uuid.uuid(), uuid.address(), PunishmentType.BAN)
                                 .thenCompose(optPunishment -> {
                                     if (optPunishment.isEmpty()) {

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
@@ -1,0 +1,34 @@
+package space.arim.libertybans.core.addon.checkuser;
+
+import net.kyori.adventure.text.Component;
+import space.arim.api.jsonchat.adventure.util.ComponentText;
+import space.arim.dazzleconf.annote.ConfDefault;
+import space.arim.dazzleconf.annote.ConfKey;
+import space.arim.libertybans.core.addon.AddonConfig;
+
+public interface CheckUserConfig extends AddonConfig {
+
+    @ConfKey("no-permission")
+    @ConfDefault.DefaultString("&cYou do not have permission to check user data")
+    Component noPermission();
+
+    @ConfDefault.DefaultString("&cUsage: /libertybans checkuser <player>")
+    Component usage();
+
+    @ConfKey("player-does-not-exist")
+    @ConfDefault.DefaultString("&cThat player does not exist")
+    Component doesNotExist();
+
+    @ConfKey("punishment-does-not-exist")
+    @ConfDefault.DefaultString("&cThat player doesn't have any active punishment.")
+    Component noPunishment();
+
+    @ConfDefault.DefaultStrings({
+            "&7Active punishment for player &e{player}",
+            "&7Type: &e%TYPE%",
+            "&7Reason: &e%REASON%",
+            "&7Operator: &e%OPERATOR%",
+            "Time remaining: &e%TIME_REMAINING%",
+    })
+    ComponentText layout();
+}

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
@@ -8,27 +8,27 @@ import space.arim.libertybans.core.addon.AddonConfig;
 
 public interface CheckUserConfig extends AddonConfig {
 
-    @ConfKey("no-permission")
-    @ConfDefault.DefaultString("&cYou do not have permission to check user data")
-    Component noPermission();
+	@ConfKey("no-permission")
+	@ConfDefault.DefaultString("&cYou do not have permission to check user data")
+	Component noPermission();
 
-    @ConfDefault.DefaultString("&cUsage: /libertybans checkuser <player>")
-    Component usage();
+	@ConfDefault.DefaultString("&cUsage: /libertybans checkuser <player>")
+	Component usage();
 
-    @ConfKey("player-does-not-exist")
-    @ConfDefault.DefaultString("&cThat player does not exist")
-    Component doesNotExist();
+	@ConfKey("player-does-not-exist")
+	@ConfDefault.DefaultString("&cThat player does not exist")
+	Component doesNotExist();
 
-    @ConfKey("punishment-does-not-exist")
-    @ConfDefault.DefaultString("&cThat player doesn't have any active punishment.")
-    Component noPunishment();
+	@ConfKey("punishment-does-not-exist")
+	@ConfDefault.DefaultString("&cThat player doesn't have any active punishment.")
+	Component noPunishment();
 
-    @ConfDefault.DefaultStrings({
-            "&7Active punishment for player &e%VICTIM%",
-            "&7Type: &e%TYPE%",
-            "&7Reason: &e%REASON%",
-            "&7Operator: &e%OPERATOR%",
-            "Time remaining: &e%TIME_REMAINING%",
-    })
-    ComponentText layout();
+	@ConfDefault.DefaultStrings({
+			"&7Active punishment for player &e%VICTIM%",
+			"&7Type: &e%TYPE%",
+			"&7Reason: &e%REASON%",
+			"&7Operator: &e%OPERATOR%",
+			"Time remaining: &e%TIME_REMAINING%",
+	})
+	ComponentText layout();
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserConfig.java
@@ -24,7 +24,7 @@ public interface CheckUserConfig extends AddonConfig {
     Component noPunishment();
 
     @ConfDefault.DefaultStrings({
-            "&7Active punishment for player &e{player}",
+            "&7Active punishment for player &e%VICTIM%",
             "&7Type: &e%TYPE%",
             "&7Reason: &e%REASON%",
             "&7Operator: &e%OPERATOR%",

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserModule.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserModule.java
@@ -7,13 +7,13 @@ import space.arim.libertybans.core.commands.SubCommandGroup;
 
 public final class CheckUserModule extends AddonBindModule {
 
-    @MultiBinding
-    public Addon<?> checkUserAddon(CheckUserAddon checkUserAddon) {
-        return checkUserAddon;
-    }
+	@MultiBinding
+	public Addon<?> checkUserAddon(CheckUserAddon checkUserAddon) {
+		return checkUserAddon;
+	}
 
-    @MultiBinding
-    public SubCommandGroup checkUserCommand(CheckUserCommand checkUserCommand) {
-        return checkUserCommand;
-    }
+	@MultiBinding
+	public SubCommandGroup checkUserCommand(CheckUserCommand checkUserCommand) {
+		return checkUserCommand;
+	}
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserModule.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserModule.java
@@ -1,0 +1,19 @@
+package space.arim.libertybans.core.addon.checkuser;
+
+import space.arim.injector.MultiBinding;
+import space.arim.libertybans.core.addon.Addon;
+import space.arim.libertybans.core.addon.AddonBindModule;
+import space.arim.libertybans.core.commands.SubCommandGroup;
+
+public final class CheckUserModule extends AddonBindModule {
+
+    @MultiBinding
+    public Addon<?> checkUserAddon(CheckUserAddon checkUserAddon) {
+        return checkUserAddon;
+    }
+
+    @MultiBinding
+    public SubCommandGroup checkUserCommand(CheckUserCommand checkUserCommand) {
+        return checkUserCommand;
+    }
+}

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserProvider.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserProvider.java
@@ -4,8 +4,8 @@ import space.arim.libertybans.core.addon.AddonBindModule;
 import space.arim.libertybans.core.addon.AddonProvider;
 
 public final class CheckUserProvider implements AddonProvider {
-    @Override
-    public AddonBindModule[] bindModules() {
-        return new AddonBindModule[] {new CheckUserModule()};
-    }
+	@Override
+	public AddonBindModule[] bindModules() {
+		return new AddonBindModule[] {new CheckUserModule()};
+	}
 }

--- a/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserProvider.java
+++ b/bans-core-addons/command-checkuser/src/main/java/space/arim/libertybans/core/addon/checkuser/CheckUserProvider.java
@@ -1,0 +1,11 @@
+package space.arim.libertybans.core.addon.checkuser;
+
+import space.arim.libertybans.core.addon.AddonBindModule;
+import space.arim.libertybans.core.addon.AddonProvider;
+
+public final class CheckUserProvider implements AddonProvider {
+    @Override
+    public AddonBindModule[] bindModules() {
+        return new AddonBindModule[] {new CheckUserModule()};
+    }
+}

--- a/bans-core-addons/pom.xml
+++ b/bans-core-addons/pom.xml
@@ -41,6 +41,7 @@
         <module>warn-actions</module>
         <module>addon-integration</module>
         <module>command-staffrollback</module>
+        <module>command-checkuser</module>
     </modules>
 
     <dependencies>

--- a/bans-core/src/main/java/module-info.java
+++ b/bans-core/src/main/java/module-info.java
@@ -39,9 +39,7 @@ module space.arim.libertybans.core {
 	exports space.arim.libertybans.core.selector;
 	exports space.arim.libertybans.core.selector.cache;
 	exports space.arim.libertybans.core.service;
-	exports space.arim.libertybans.core.uuid
-			to space.arim.dazzleconf, space.arim.injector;
-
+	exports space.arim.libertybans.core.uuid;
 	opens space.arim.libertybans.core.alts to space.arim.dazzleconf;
 	opens space.arim.libertybans.core.commands.extra to space.arim.dazzleconf;
 	opens space.arim.libertybans.core.config to space.arim.dazzleconf;

--- a/docs/Addons.md
+++ b/docs/Addons.md
@@ -32,6 +32,12 @@ This addon provides the `/libertybans checkpunish <ID>` command. This command di
 
 Requires the permission `libertybans.addon.checkpunish.use`.
 
+## CheckUser
+
+Provides the `/libertybans checkuser <player>` command. This command displays if the given player is banned or muted.
+
+Requires the permission `libertybans.addon.checkuser.use`.
+
 ## StaffRollback
 
 Provides the `/libertybans staffrollback <operator> [time]` command. Performing a rollback fully purges all punishments by a certain staff member, which is useful if a staff member becomes rogue or has their account hacked.

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
 		<module>bans-core-addons</module>
 		<module>bans-env</module>
 		<module>bans-distribution</module>
-	</modules>
+    </modules>
 
 	<distributionManagement>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
 		<module>bans-core-addons</module>
 		<module>bans-env</module>
 		<module>bans-distribution</module>
-    </modules>
+	</modules>
 
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
This addon is quite similar to the actual CheckPunish addon but instead of using the punishment id to check punishment data it uses the player name and returns if its ban or muted.

As far as I know, this addon works as intented and has no known errors.