### PR TITLE
Add method to get back a builder from a DraftPunishment

### DIFF
--- a/bans-api/src/main/java/space/arim/libertybans/api/punish/DraftPunishment.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/punish/DraftPunishment.java
@@ -73,6 +73,13 @@ public interface DraftPunishment extends PunishmentBase, EnforcementOptionsFacto
 	ReactionStage<Optional<Punishment>> enactPunishment(EnforcementOptions enforcementOptions);
 
 	/**
+	 * Creates a new {@link DraftPunishmentBuilder}, copying all properties of this draft.
+	 *
+	 * @return A new builder
+	 */
+	DraftPunishmentBuilder toBuilder();
+
+	/**
 	 * Whether this draft punishment is equal to another. The other draft punishment
 	 * must have the same details as this one
 	 * 

--- a/bans-core/src/main/java/space/arim/libertybans/core/punish/DraftPunishmentImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/punish/DraftPunishmentImpl.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import space.arim.libertybans.api.punish.DraftPunishmentBuilder;
 import space.arim.libertybans.api.punish.EnforcementOptions;
 import space.arim.omnibus.util.concurrent.ReactionStage;
 
@@ -52,6 +53,17 @@ class DraftPunishmentImpl extends AbstractPunishmentBase implements DraftPunishm
 			}
 			return punishment.enforcePunishment(enforcementOptions).thenApply((ignore) -> Optional.of(punishment));
 		});
+	}
+
+	@Override
+	public DraftPunishmentBuilder toBuilder() {
+		return enactor.draftBuilder()
+				.type(getType())
+				.victim(getVictim())
+				.operator(getOperator())
+				.reason(getReason())
+				.duration(getDuration())
+				.scope(getScope());
 	}
 
 	@Override


### PR DESCRIPTION
This adds a convenience method to DraftPunishment to construct a new builder, copying all its properties.
This PR in combination with https://github.com/A248/LibertyBans/pull/212 are to address https://github.com/A248/LibertyBans/issues/130
A unit test is still required, but I didn't really know where to put it. Some advise on that would be greatly appreciated.
Javadoc could probably also be improved.
