### PR TITLE
Add DraftPunishment setter to PunishEvent

### DIFF
--- a/bans-api/src/main/java/space/arim/libertybans/api/event/PunishEvent.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/event/PunishEvent.java
@@ -42,4 +42,15 @@ public interface PunishEvent extends Cancellable, AsyncEvent {
 	 */
 	DraftPunishment getDraftPunishment();
 
+
+	/**
+	 * Sets the draft punishment which will be put into place. <br>
+	 *
+	 * The draft punishment includes the operator who is enacting this punishment,
+	 * the victim who is being punished, and several other details.
+	 *
+	 * @param draftPunishment the new draft punishment
+	 */
+	void setDraftPunishment(DraftPunishment draftPunishment);
+
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/commands/PunishCommands.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/commands/PunishCommands.java
@@ -201,12 +201,12 @@ abstract class PunishCommands extends AbstractSubCommandGroup implements PunishU
 					return completedFuture(null);
 				}
 				// Enforce the punishment later, after we are sure it is valid
-				EnforcementOptions enforcementOptions = draftPunishment
+				EnforcementOptions enforcementOptions = event.getDraftPunishment()
 						.enforcementOptionsBuilder()
 						.enforcement(EnforcementOptions.Enforcement.NONE)
 						.broadcasting(EnforcementOptions.Broadcasting.NONE)
 						.build();
-				return draftPunishment.enactPunishment(enforcementOptions).thenApply((optPunishment) -> {
+				return event.getDraftPunishment().enactPunishment(enforcementOptions).thenApply((optPunishment) -> {
 					if (optPunishment.isEmpty()) {
 						sendConflict(targetArg);
 						return null;

--- a/bans-core/src/main/java/space/arim/libertybans/core/event/PunishEventImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/event/PunishEventImpl.java
@@ -25,7 +25,7 @@ import space.arim.libertybans.api.punish.DraftPunishment;
 
 public class PunishEventImpl extends AbstractCancellable implements PunishEvent {
 
-	private final DraftPunishment draftPunishment;
+	private DraftPunishment draftPunishment;
 
 	public PunishEventImpl(DraftPunishment draftPunishment) {
 		this.draftPunishment = Objects.requireNonNull(draftPunishment);
@@ -36,4 +36,8 @@ public class PunishEventImpl extends AbstractCancellable implements PunishEvent 
 		return draftPunishment;
 	}
 
+	@Override
+	public void setDraftPunishment(DraftPunishment draftPunishment) {
+		this.draftPunishment = draftPunishment;
+	}
 }


### PR DESCRIPTION
Adds a setter for the DraftPunishment into PunishEvent. The event's getter is then used to get the draft that is actually enforced.
This PR in combination with https://github.com/A248/LibertyBans/pull/211 are to address https://github.com/A248/LibertyBans/issues/130