### PR TITLE
Check for the DOCKER_HOST variable instead of the Docker sock file.

### DIFF
--- a/bans-core/pom.xml
+++ b/bans-core/pom.xml
@@ -268,9 +268,9 @@
 		<profile>
 			<id>docker-enabled</id>
 			<activation>
-				<file>
-					<exists>/var/run/docker.sock</exists>
-				</file>
+				<property>
+					<name>env.DOCKER_HOST</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>
@@ -348,9 +348,9 @@
 		<profile>
 			<id>docker-database-mariadb</id>
 			<activation>
-				<file>
-					<exists>/var/run/docker.sock</exists>
-				</file>
+				<property>
+					<name>env.DOCKER_HOST</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>
@@ -470,9 +470,9 @@
 		<profile>
 			<id>docker-database-mysql</id>
 			<activation>
-				<file>
-					<exists>/var/run/docker.sock</exists>
-				</file>
+				<property>
+					<name>env.DOCKER_HOST</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>
@@ -534,9 +534,9 @@
 		<profile>
 			<id>docker-database-postgres</id>
 			<activation>
-				<file>
-					<exists>/var/run/docker.sock</exists>
-				</file>
+				<property>
+					<name>env.DOCKER_HOST</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>
@@ -627,9 +627,9 @@
 		<profile>
 			<id>docker-database-cockroachdb</id>
 			<activation>
-				<file>
-					<exists>/var/run/docker.sock</exists>
-				</file>
+				<property>
+					<name>env.DOCKER_HOST</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>


### PR DESCRIPTION
In certain scenarios, when Docker is installed the sock may be present in a different location. For as an example, when installing docker in a [rootless environment](https://docs.docker.com/engine/security/rootless/), the sock location will be [different](https://github.com/moby/moby/blob/master/contrib/dockerd-rootless-setuptool.sh#L412) based on the installation type.

This change should also maintain compatibility with installations where the sock is in the default location, as by default Docker always sets this environment variable.