### PR TITLE
Alts registration per server

### DIFF
--- a/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2022 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -76,6 +76,9 @@ public interface PunishmentSelector {
 	 * For example, if a ban would prevent a player from joining the server, the ban is said to be applicable to
 	 * the player's UUID and IP. It may be, the player's IP is banned, the player's UUID is banned,
 	 * or the player has played on a banned IP and that IP is banned  while strict address enforcement is enabled. <br>
+	 * <br>
+	 * For maximum accuracy, the UUID and IP address pair should be taken from an actual user who has logged on before.
+	 * Due to specifics in terms of how applicability is computed, some punishments
 	 * <br>
 	 * By default, the server's configured address strictness is used, but this may be changed if desired.
 	 *

--- a/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
@@ -60,7 +60,8 @@ public interface PunishmentSelector {
 	 * the player's UUID and IP. It may be, the player's IP is banned, the player's UUID is banned,
 	 * or the player has played on a banned IP and that IP is banned  while strict address enforcement is enabled. <br>
 	 * <br>
-	 * By default, the server's configured address strictness is used, but this may be changed if desired.
+	 * By default, the server's configured address strictness is used, but the caller can use
+	 * {@link SelectionByApplicabilityBuilder#addressStrictness(AddressStrictness)} to change the setting.
 	 *
 	 * @param uuid the uuid of the user for whom to select applicable punishments
 	 * @param address the current or most recent address of the same user
@@ -78,9 +79,11 @@ public interface PunishmentSelector {
 	 * or the player has played on a banned IP and that IP is banned  while strict address enforcement is enabled. <br>
 	 * <br>
 	 * For maximum accuracy, the UUID and IP address pair should be taken from an actual user who has logged on before.
-	 * Due to specifics in terms of how applicability is computed, some punishments
+	 * Due to the specifics of how applicability is computed, some punishments may not be considered if the UUID and
+	 * IP address have not been recorded in account history.
 	 * <br>
-	 * By default, the server's configured address strictness is used, but this may be changed if desired.
+	 * By default, the server's configured address strictness is used, but the caller can use
+	 * {@link SelectionByApplicabilityBuilder#addressStrictness(AddressStrictness)} to change the setting.
 	 *
 	 * @param uuid the uuid of the user for whom to select applicable punishments
 	 * @param address the current or most recent address of the same user

--- a/bans-core/src/main/java/space/arim/libertybans/core/database/sql/ApplicableViewFields.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/database/sql/ApplicableViewFields.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2023 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -31,7 +31,6 @@ import space.arim.libertybans.api.punish.EscalationTrack;
 import space.arim.libertybans.core.scope.ScopeType;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 
 public record ApplicableViewFields<R extends Record14<
@@ -111,7 +110,11 @@ public record ApplicableViewFields<R extends Record14<
 	}
 
 	public Field<UUID> uuid() {
-		return Objects.requireNonNull(fieldSupplier.field11(), "uuid field does not exist");
+		return fieldSupplier.field11();
+	}
+
+	public Field<NetworkAddress> address() {
+		return fieldSupplier.field12();
 	}
 
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2022 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -152,8 +152,8 @@ public interface EnforcementConfig {
 				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
-		@DefaultStrings("")
-		List<String> servers();
+		@DefaultStrings({"auth"})
+		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
 				"If you are running a Proxy and don't want to register the IP when players connect, ",

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -140,6 +140,7 @@ public interface EnforcementConfig {
 
 	}
 
+	@ConfKey("alts-registry")
 	@SubSection
 	AltsRegistry altsRegistry();
 
@@ -147,18 +148,18 @@ public interface EnforcementConfig {
 	interface AltsRegistry {
 
 		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
-				"Please note that the server's name of the list should be the same as the ones in your proxy config",
+				"Please note that the server's name in the list should be the same as the ones in your proxy configuration.",
 				"This is intended to be used by LibertyBans proxy installations.",
-				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
+				"If you are planning to use this feature, you MUST enable the 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings({"auth"})
 		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
-				"If you are running a Proxy and don't want to register the IP when players connect, ",
-				"set this to false and add the auth server names in the list above.",
-				"If this is a backend server, then set it to false if it's an auth server, and true otherwise."})
+				"If you are running a proxy and don't want to register the IP when players connect, ",
+				"set this to false and add the authentication servers' names in the list above.",
+				"If this is a backend server, set it to false; if it's an authentication server, set to true."})
 		@ConfKey("should-register-on-connection)")
 		@ConfDefault.DefaultBoolean(true)
 		boolean shouldRegisterOnConnection();

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -158,9 +158,9 @@ public interface EnforcementConfig {
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
 				"If you are running a proxy and don't want to register the IP when players connect, ",
-				"set this to false and add the authentication servers' names in the list above.",
-				"If this is a backend server, set it to false; if it's an authentication server, set to true."})
-		@ConfKey("should-register-on-connection)")
+				"set this to false and add the servers' names in the list above.",
+				})
+		@ConfKey("should-register-on-connection")
 		@ConfDefault.DefaultBoolean(true)
 		boolean shouldRegisterOnConnection();
 	}

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -148,7 +148,8 @@ public interface EnforcementConfig {
 
 		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
 				"Please note that the server's name of the list should be the same as the ones in your proxy config",
-				"This is intended to be used by LibertyBans proxy installations."
+				"This is intended to be used by LibertyBans proxy installations.",
+				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings("")

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -146,23 +146,20 @@ public interface EnforcementConfig {
 	@ConfHeader({"Controls if all servers should register the IP address of the player connecting."})
 	interface AltsRegistry {
 
-		@ConfComments("If true, all servers will register alts.")
-		@ConfKey("enable-all")
-		@ConfDefault.DefaultBoolean(true)
-		boolean enableAll();
-
-		@ConfComments({"If enableAll is false, this list will be used ",
-				"to determine which servers will register alts.",
+		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
 				"Please note that the server's name of the list should be the same as the ones in your proxy config",
-				"This is intended to be used by LibertyBans proxy installations.",
-				"If this is a backend server, please skip this option."})
-		@ConfKey("servers")
+				"This is intended to be used by LibertyBans proxy installations."
+				})
+		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings("")
 		List<String> servers();
 
-		@ConfComments({"If true, this backend server will register alts"})
-		@ConfKey("should-register")
+		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
+				"If you are running a Proxy and don't want to register the IP when players connect, ",
+				"set this to false and add the auth server names in the list above.",
+				"If this is a backend server, then set it to false if it's an auth server, and true otherwise."})
+		@ConfKey("should-register-on-connection)")
 		@ConfDefault.DefaultBoolean(true)
-		boolean shouldRegister();
+		boolean shouldRegisterOnConnection();
 	}
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -150,10 +150,11 @@ public interface EnforcementConfig {
 		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
 				"Please note that the server's name in the list should be the same as the ones in your proxy configuration.",
 				"This is intended to be used by LibertyBans proxy installations.",
-				"If you are planning to use this feature, you MUST enable the 'enforce-server-switch' option."
+				"If you are planning to use this feature, you MUST enable the 'enforce-server-switch' option.",
+				"If you are not using LibertyBans in the proxy, you should leave this list empty."
 				})
 		@ConfKey("servers-without-ip-registration")
-		@DefaultStrings({"auth"})
+		@DefaultStrings({"server-name"})
 		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -142,7 +142,7 @@ public interface EnforcementConfig {
 
 	@ConfKey("alts-registry")
 	@SubSection
-	AltsRegistry altsRegistry();
+	AltsRegistry altsRegistry(); // Sensitive name used in integration testing
 
 	@ConfHeader({"Controls if all servers should register the IP address of the player connecting."})
 	interface AltsRegistry {
@@ -154,7 +154,7 @@ public interface EnforcementConfig {
 				"If you are not using LibertyBans in the proxy, you should leave this list empty."
 				})
 		@ConfKey("servers-without-ip-registration")
-		@DefaultStrings({"server-name"})
+		@DefaultStrings({"auth", "server-name"})
 		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -19,6 +19,7 @@
 
 package space.arim.libertybans.core.selector;
 
+import java.util.List;
 import java.util.Set;
 
 import space.arim.dazzleconf.annote.ConfComments;
@@ -137,5 +138,31 @@ public interface EnforcementConfig {
 		@NumericRange(min = 1)
 		long expirationTimeDays();
 
+	}
+
+	@SubSection
+	AltsRegistry altsRegistry();
+
+	@ConfHeader({"Controls if all servers should register the IP address of the player connecting."})
+	interface AltsRegistry {
+
+		@ConfComments("If true, all servers will register alts.")
+		@ConfKey("enable-all")
+		@ConfDefault.DefaultBoolean(true)
+		boolean enableAll();
+
+		@ConfComments({"If enableAll is false, this list will be used ",
+				"to determine which servers will register alts.",
+				"Please note that the server's name of the list should be the same as the ones in your proxy config",
+				"This is intended to be used by LibertyBans proxy installations.",
+				"If this is a backend server, please skip this option."})
+		@ConfKey("servers")
+		@DefaultStrings("")
+		List<String> servers();
+
+		@ConfComments({"If true, this backend server will register alts"})
+		@ConfKey("should-register")
+		@ConfDefault.DefaultBoolean(true)
+		boolean shouldRegister();
 	}
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -119,17 +119,16 @@ public final class Gatekeeper {
 
 	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address,
 																	String destinationServer, ServerScope scope, SelectorImpl selector) {
+		if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
+			return null;
+		}
 
 		return queryExecutor.get().queryWithRetry((context, transaction) -> {
 			boolean shouldRegister = configs.getMainConfig().enforcement().altsRegistry().shouldRegisterOnConnection();
 			List<String> servers = configs.getMainConfig().enforcement().altsRegistry().servers();
 
-			if (shouldRegister || !servers.contains(destinationServer)) {
+			if (!shouldRegister && !servers.contains(destinationServer)) {
 				doAssociation(uuid, name, address, time.currentTimestamp(), context);
-			}
-
-			if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
-				return null;
 			}
 
 			return selector.selectionByApplicabilityBuilder(uuid, address)

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -26,7 +26,6 @@ import org.jooq.DSLContext;
 import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.punish.Punishment;
-import space.arim.libertybans.api.scope.ScopeManager;
 import space.arim.libertybans.api.scope.ServerScope;
 import space.arim.libertybans.api.select.SelectionPredicate;
 import space.arim.libertybans.api.select.SortPunishments;
@@ -57,12 +56,11 @@ public final class Gatekeeper {
 	private final AltDetection altDetection;
 	private final AltNotification altNotification;
 	private final Time time;
-	private final ScopeManager scopeManager;
 
 	@Inject
 	public Gatekeeper(Configs configs, FactoryOfTheFuture futuresFactory, Provider<QueryExecutor> queryExecutor,
 					  InternalFormatter formatter, ConnectionLimiter connectionLimiter, AltDetection altDetection,
-					  AltNotification altNotification, Time time, ScopeManager scopeManager) {
+					  AltNotification altNotification, Time time) {
 		this.configs = configs;
 		this.futuresFactory = futuresFactory;
 		this.queryExecutor = queryExecutor;
@@ -71,7 +69,6 @@ public final class Gatekeeper {
 		this.altDetection = altDetection;
 		this.altNotification = altNotification;
 		this.time = time;
-		this.scopeManager = scopeManager;
 	}
 
 	CentralisedFuture<Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address,

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -77,7 +77,6 @@ public final class Gatekeeper {
 			Instant currentTime = time.currentTimestamp();
 
 			EnforcementConfig config = configs.getMainConfig().enforcement();
-
 			if (config.altsRegistry().enableAll()) {
 				doAssociation(uuid, name, address, currentTime, context);
 

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Guardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Guardian.java
@@ -35,9 +35,9 @@ public interface Guardian {
 	 * Adds the uuid and name to the local fast cache, queries for an applicable ban, and formats the
 	 * ban reason as the punishment message.
 	 *
-	 * @param uuid the player's uuid
-	 * @param name the player's name
-	 * @param address the player's network address
+	 * @param uuid       the player's uuid
+	 * @param name       the player's name
+	 * @param address    the player's network address
 	 * @return a future which yields the punishment message if denied, else null if allowed
 	 */
 	CentralisedFuture<@Nullable Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address);
@@ -63,11 +63,27 @@ public interface Guardian {
 	 * Queries for an applicable ban, and formats the ban reason as the punishment message.
 	 *
 	 * @param uuid the player's uuid
+	 * @param name the player's name
 	 * @param address the player's network address
 	 * @param destinationServer the player's destination server
 	 * @return a future which yields the punishment message if denied, else null if allowed
 	 */
-	CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, InetAddress address, String destinationServer);
+	CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address, String destinationServer);
+
+	/**
+	 * Enforces a server switch, returning a punishment message if denied, null if allowed. <br>
+	 * <br>
+	 * Queries for an applicable ban, and formats the ban reason as the punishment message.
+	 *
+	 * @param uuid the player's uuid
+	 * @param name the player's name
+	 * @param address the player's network address
+	 * @param destinationServer the player's destination server
+	 * @return a future which yields the punishment message if denied, else null if allowed
+	 */
+	default CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, InetAddress address, String destinationServer) {
+		return checkServerSwitch(uuid, name, NetworkAddress.of(address), destinationServer);
+	}
 
 	/**
 	 * Enforces a chat message or executed command, returning a punishment message if denied, null if allowed. <br>

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -32,7 +32,6 @@ import space.arim.libertybans.core.uuid.UUIDManager;
 import space.arim.omnibus.util.concurrent.CentralisedFuture;
 import space.arim.omnibus.util.concurrent.FactoryOfTheFuture;
 
-import java.net.InetAddress;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -100,8 +100,7 @@ public final class IntelligentGuardian implements Guardian {
 																	String destinationServer) {
 		return selector
 				.executeAndCheckServerSwitch(
-						uuid, name, address,
-						scopeManager.specificScope(destinationServer), destinationServer
+						uuid, name, address, destinationServer
 				)
 				.toCompletableFuture()
 				.orTimeout(12, TimeUnit.SECONDS)

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -24,9 +24,7 @@ import jakarta.inject.Singleton;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import space.arim.libertybans.api.NetworkAddress;
-import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.scope.ScopeManager;
-import space.arim.libertybans.api.select.SortPunishments;
 import space.arim.libertybans.core.config.Configs;
 import space.arim.libertybans.core.config.InternalFormatter;
 import space.arim.libertybans.core.selector.cache.MuteCache;
@@ -98,23 +96,13 @@ public final class IntelligentGuardian implements Guardian {
 	}
 
 	@Override
-	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, InetAddress address,
+	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address,
 																	String destinationServer) {
-		if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
-			return futuresFactory.completedFuture(null);
-		}
 		return selector
-				.selectionByApplicabilityBuilder(uuid, address)
-				.type(PunishmentType.BAN)
-				.scope(scopeManager.specificScope(destinationServer))
-				.build()
-				.getFirstSpecificPunishment(SortPunishments.LATEST_END_DATE_FIRST)
-				.thenCompose((punishment) -> {
-					if (punishment.isEmpty()) {
-						return futuresFactory.completedFuture(null);
-					}
-					return formatter.getPunishmentMessage(punishment.get());
-				})
+				.executeAndCheckServerSwitch(
+						uuid, name, address,
+						scopeManager.specificScope(destinationServer), destinationServer
+				)
 				.toCompletableFuture()
 				.orTimeout(12, TimeUnit.SECONDS)
 				.exceptionally(timeoutHandler("server switch"));

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
@@ -59,10 +59,9 @@ public interface InternalSelector extends PunishmentSelector {
 	 * @param uuid		the player uuid
 	 * @param name		the player name
 	 * @param address	the player address
-	 * @param scope		the server scope to include in the selection query
 	 * @param destinationServer the server the player is switching to
 	 * @return a future which yields the denial message, or null if there is none
 	 */
 	CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
-															 ServerScope scope, String destinationServer);
+															 String destinationServer);
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
@@ -42,14 +42,27 @@ public interface InternalSelector extends PunishmentSelector {
 	/**
 	 * Checks a player connection's in a single connection query, enforcing any applicable bans,
 	 * connection limits, and dealing out alt checks
-	 * 
-	 * @param uuid the player uuid
-	 * @param name the player name
-	 * @param address the player address
-	 * @param scopes the server scopes to include in the selection query
+	 *
+	 * @param uuid       the player uuid
+	 * @param name       the player name
+	 * @param address    the player address
+	 * @param scopes     the server scopes to include in the selection query
 	 * @return a future which yields the denial message, or null if there is none
 	 */
 	CentralisedFuture<Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address,
 														   Set<ServerScope> scopes);
 
+	/**
+	 * Checks a player connection's in a single connection query, enforcing any applicable bans if
+	 * enforce server switch is enabled.
+	 *
+	 * @param uuid		the player uuid
+	 * @param name		the player name
+	 * @param address	the player address
+	 * @param scope		the server scope to include in the selection query
+	 * @param destinationServer the server the player is switching to
+	 * @return a future which yields the denial message, or null if there is none
+	 */
+	CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
+															 ServerScope scope, String destinationServer);
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2023 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,7 @@ public final class SelectionByApplicabilityBuilderImpl
 	private final NetworkAddress address;
 	private AddressStrictness strictness;
 	private final AddressStrictness defaultStrictness;
+	private boolean potentialNewEntrant;
 
 	SelectionByApplicabilityBuilderImpl(SelectionResources resources,
 										UUID uuid, NetworkAddress address, AddressStrictness defaultStrictness) {
@@ -68,7 +69,7 @@ public final class SelectionByApplicabilityBuilderImpl
 	@Override
 	SelectionByApplicability buildWith(SelectionBaseImpl.Details details) {
 		return new SelectionByApplicabilityImpl(
-				details, resources, uuid, address, strictness
+				details, resources, uuid, address, strictness, potentialNewEntrant
 		);
 	}
 
@@ -87,6 +88,19 @@ public final class SelectionByApplicabilityBuilderImpl
 	@Override
 	public SelectionByApplicabilityImpl build() {
 		return (SelectionByApplicabilityImpl) super.build();
+	}
+
+	/**
+	 * For internal use, to accomodate a new user whose UUID and IP address combination
+	 * has not yet been entered to the database. Sets whether this scenario is potential.
+	 *
+	 * @param canAssumeUserRecorded if the user is definitely registered, set to true. True by default.
+	 * @return this builder
+	 */
+	public SelectionByApplicabilityBuilderImpl canAssumeUserRecorded(boolean canAssumeUserRecorded) {
+		// A user is a potential new entrant if we can't assume they're recorded
+		this.potentialNewEntrant = !canAssumeUserRecorded;
+		return this;
 	}
 
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
@@ -91,7 +91,7 @@ public final class SelectionByApplicabilityBuilderImpl
 	}
 
 	/**
-	 * For internal use, to accomodate a new user whose UUID and IP address combination
+	 * For internal use, to accommodate a new user whose UUID and IP address combination
 	 * has not yet been entered to the database. Sets whether this scenario is potential.
 	 *
 	 * @param canAssumeUserRecorded if the user is definitely registered, set to true. True by default.

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
@@ -26,6 +26,7 @@ import net.kyori.adventure.text.Component;
 import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.punish.Punishment;
+import space.arim.libertybans.api.scope.ScopeManager;
 import space.arim.libertybans.api.scope.ServerScope;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.api.select.SelectionOrderBuilder;
@@ -47,15 +48,18 @@ public class SelectorImpl implements InternalSelector {
 	private final Gatekeeper gatekeeper;
 	private final Provider<MuteCache> muteCache;
 	private final SelectionResources resources;
+	private final ScopeManager scopeManager;
 
 	@Inject
 	public SelectorImpl(Configs configs, IDImpl idImpl, Gatekeeper gatekeeper,
-						Provider<MuteCache> muteCache, SelectionResources resources) {
+						Provider<MuteCache> muteCache, SelectionResources resources,
+						ScopeManager scopeManager) {
 		this.configs = configs;
 		this.idImpl = idImpl;
 		this.gatekeeper = gatekeeper;
 		this.muteCache = muteCache;
 		this.resources = resources;
+		this.scopeManager = scopeManager;
 	}
 
 	@Override
@@ -114,8 +118,9 @@ public class SelectorImpl implements InternalSelector {
 
 	@Override
 	public CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
-																	ServerScope scope, String destinationServer) {
-		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer, scope, this);
+																	String destinationServer) {
+		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer,
+				scopeManager.specificScope(destinationServer), this);
 	}
 
 	@Override

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
@@ -113,6 +113,12 @@ public class SelectorImpl implements InternalSelector {
 	}
 
 	@Override
+	public CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
+																	ServerScope scope, String destinationServer) {
+		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer, scope, this);
+	}
+
+	@Override
 	public ReactionStage<Optional<Punishment>> getCachedMute(UUID uuid, NetworkAddress address) {
 		Objects.requireNonNull(uuid, "uuid");
 		Objects.requireNonNull(address, "address");

--- a/bans-core/src/test/java/space/arim/libertybans/core/config/SpecifiedConfigs.java
+++ b/bans-core/src/test/java/space/arim/libertybans/core/config/SpecifiedConfigs.java
@@ -27,6 +27,7 @@ import space.arim.libertybans.core.uuid.ServerType;
 import space.arim.libertybans.core.uuid.UUIDResolutionConfig;
 import space.arim.libertybans.it.ConfigSpec;
 import space.arim.libertybans.it.DatabaseInfo;
+import space.arim.libertybans.it.SetAltRegistry;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -100,6 +101,25 @@ public class SpecifiedConfigs implements Configs {
 					Object replacementFor(EnforcementConfig original, String methodName) {
 						if (methodName.equals("addressStrictness")) {
 							return spec.addressStrictness();
+						}
+						if (methodName.equals("altsRegistry")) {
+							SetAltRegistry.Option option = spec.altRegistryOption();
+							return new EnforcementConfig.AltsRegistry() {
+								@Override
+								public List<String> serversWithoutRegistration() {
+									return switch (option) {
+										case ON_CONNECTION -> List.of();
+										case ON_SERVER_SWITCH -> List.of(
+												SetAltRegistry.Option.NON_REGISTERING_SERVER_NAME
+										);
+									};
+								}
+
+								@Override
+								public boolean shouldRegisterOnConnection() {
+									return option == SetAltRegistry.Option.ON_CONNECTION;
+								}
+							};
 						}
 						return null;
 					}

--- a/bans-core/src/test/java/space/arim/libertybans/it/ConfigSpec.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/ConfigSpec.java
@@ -27,12 +27,13 @@ import space.arim.libertybans.core.uuid.ServerType;
 import java.time.Instant;
 import java.util.Objects;
 
-public record ConfigSpec(Vendor vendor, AddressStrictness addressStrictness, ServerType serverType,
-						 InstanceType instanceType, boolean pluginMessaging, long unixTime) {
+public record ConfigSpec(Vendor vendor, AddressStrictness addressStrictness, SetAltRegistry.Option altRegistryOption,
+						 ServerType serverType, InstanceType instanceType, boolean pluginMessaging, long unixTime) {
 
 	public ConfigSpec {
 		Objects.requireNonNull(vendor, "vendor");
 		Objects.requireNonNull(addressStrictness, "addressStrictness");
+		Objects.requireNonNull(altRegistryOption, "altRegistryOption");
 		Objects.requireNonNull(serverType, "serverType");
 		Objects.requireNonNull(instanceType, "instanceType");
 	}

--- a/bans-core/src/test/java/space/arim/libertybans/it/SetAltRegistry.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/SetAltRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * LibertyBans
+ * Copyright © 2025 Anand Beh
+ *
+ * LibertyBans is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * LibertyBans is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with LibertyBans. If not, see <https://www.gnu.org/licenses/>
+ * and navigate to version 3 of the GNU Affero General Public License.
+ */
+
+package space.arim.libertybans.it;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface SetAltRegistry {
+
+    /**
+     * The settings to test against.
+     *
+     * @return the alt registry options
+     */
+    Option[] value() default {};
+
+    /**
+     * Whether to test against all alt registry options. Overrides {@code value}
+     *
+     * @return true to use all options
+     */
+    boolean all() default false;
+
+    enum Option {
+        /**
+         * Registers on immediate connection. The default behavior.
+         */
+        ON_CONNECTION,
+        /**
+         * Registers the player account when they switch to another server, except {@link #NON_REGISTERING_SERVER_NAME}
+         */
+        ON_SERVER_SWITCH;
+
+        public static final String NON_REGISTERING_SERVER_NAME = "no_register_alts";
+    }
+}

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/LateRegistrationIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/LateRegistrationIT.java
@@ -1,0 +1,95 @@
+/*
+ * LibertyBans
+ * Copyright © 2025 Anand Beh
+ *
+ * LibertyBans is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * LibertyBans is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with LibertyBans. If not, see <https://www.gnu.org/licenses/>
+ * and navigate to version 3 of the GNU Affero General Public License.
+ */
+
+package space.arim.libertybans.it.test.applicable;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import space.arim.libertybans.api.AddressVictim;
+import space.arim.libertybans.api.ConsoleOperator;
+import space.arim.libertybans.api.PunishmentType;
+import space.arim.libertybans.api.punish.PunishmentDrafter;
+import space.arim.libertybans.api.select.AddressStrictness;
+import space.arim.libertybans.core.selector.Guardian;
+import space.arim.libertybans.it.InjectionInvocationContextProvider;
+import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
+import space.arim.libertybans.it.SetTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is technically redundant, since the logic of late registration is covered through: <ul>
+ *     <li>AccountHistoryIT, which checks for the late registration of account history</li>
+ *     <li>The other ITs in this package, which use <code>@SetAltRegistry(all = true)</code> to ensure that punishments
+ *     follow the same applicability rules, regardless of late registration</li>
+ * </ul>
+ *
+ */
+@ExtendWith(InjectionInvocationContextProvider.class)
+public class LateRegistrationIT {
+
+    @TestTemplate
+    @SetAddressStrictness(AddressStrictness.NORMAL)
+    @SetAltRegistry(SetAltRegistry.Option.ON_SERVER_SWITCH)
+    // We use a consistent time in order to get the same punishment message
+    @SetTime(unixTime = 1751274626)
+    public void unregisteredAccountsDoNotBuildLinks(PunishmentDrafter drafter, Guardian guardian) {
+        // If late registration is disabled, account history is built up every time someone connections
+        // So, in this test, we check that new connections cannot cause existing accounts to become banned
+
+        User guiltyUser = User.randomUser();
+        User innocentUser = User.randomUser();
+        User cleverHacker = new User(innocentUser.uuid(), guiltyUser.address());
+
+        // In the beginning, both guiltyUser and innocentUser are free to join
+        assertNull(guardian.executeAndCheckConnection(guiltyUser.uuid(), "GuiltyPlayer", guiltyUser.address()).join());
+        assertNull(guardian.checkServerSwitch(guiltyUser.uuid(), "GuiltyPlayer", guiltyUser.address(), "please_register").join());
+        assertNull(guardian.executeAndCheckConnection(innocentUser.uuid(), "InnocentPlayer", innocentUser.address()).join());
+        assertNull(guardian.checkServerSwitch(innocentUser.uuid(), "InnocentPLayer", innocentUser.address(), "please_register").join());
+
+        // Now add the ban
+        drafter.draftBuilder()
+                .type(PunishmentType.BAN)
+                .victim(AddressVictim.of(guiltyUser.address()))
+                .operator(ConsoleOperator.INSTANCE)
+                .reason("Banned for life")
+                .build()
+                .enactPunishment()
+                .toCompletableFuture()
+                .join();
+
+        // Both the banned player, and the clever alt, are banned
+        Component banMsg = guardian.executeAndCheckConnection(
+                guiltyUser.uuid(), "BannedPlayer", guiltyUser.address()
+        ).join();
+        assertNotNull(banMsg);
+
+        Component stillBanMsg = guardian.executeAndCheckConnection(
+                cleverHacker.uuid(), "CleverPlayer", cleverHacker.address()
+        ).join();
+        assertNotNull(stillBanMsg);
+        assertEquals(banMsg, stillBanMsg);
+
+        // However, the innocent player is still not banned
+        assertNull(guardian.executeAndCheckConnection(innocentUser.uuid(), "NameChange", innocentUser.address()).join());
+        assertNull(guardian.checkServerSwitch(innocentUser.uuid(), "NameChange", innocentUser.address(), "please_register").join());
+    }
+}

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/LenientStrictnessIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/LenientStrictnessIT.java
@@ -28,6 +28,7 @@ import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.it.InjectionInvocationContextProvider;
 import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
 import space.arim.libertybans.it.util.RandomUtil;
 
 import java.util.UUID;
@@ -44,6 +45,7 @@ public class LenientStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.LENIENT)
+	@SetAltRegistry(all = true)
 	public void enforceAddressBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 
@@ -77,6 +79,7 @@ public class LenientStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.LENIENT)
+	@SetAltRegistry(all = true)
 	public void enforceCompositeBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/MultipleApplicableIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/MultipleApplicableIT.java
@@ -35,10 +35,7 @@ import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.api.select.PunishmentSelector;
 import space.arim.libertybans.api.select.SortPunishments;
 import space.arim.libertybans.core.service.SettableTime;
-import space.arim.libertybans.it.DontInject;
-import space.arim.libertybans.it.InjectionInvocationContextProvider;
-import space.arim.libertybans.it.IrrelevantData;
-import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.*;
 import space.arim.libertybans.it.resolver.RandomOperatorResolver;
 import space.arim.libertybans.it.util.RandomUtil;
 
@@ -88,6 +85,7 @@ public class MultipleApplicableIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.NORMAL)
+	@SetAltRegistry(all = true)
 	@IrrelevantData
 	public void selectHistory() {
 		UUID uuid = UUID.randomUUID();
@@ -114,6 +112,7 @@ public class MultipleApplicableIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.STRICT)
+	@SetAltRegistry(all = true)
 	@IrrelevantData
 	public void avoidDuplicateApplicablePunishments() {
 		UUID uuid = UUID.randomUUID();

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/NormalStrictnessIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/NormalStrictnessIT.java
@@ -28,6 +28,7 @@ import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.it.InjectionInvocationContextProvider;
 import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
 import space.arim.libertybans.it.util.RandomUtil;
 
 import java.util.UUID;
@@ -44,6 +45,7 @@ public class NormalStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.NORMAL)
+	@SetAltRegistry(all = true)
 	public void enforceAddressBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 
@@ -78,6 +80,7 @@ public class NormalStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.NORMAL)
+	@SetAltRegistry(all = true)
 	public void enforceCompositeBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/NotYetBannedIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/NotYetBannedIT.java
@@ -26,6 +26,7 @@ import space.arim.libertybans.api.AddressVictim;
 import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.it.InjectionInvocationContextProvider;
 import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
 import space.arim.libertybans.it.util.RandomUtil;
 
 import java.util.UUID;
@@ -42,6 +43,7 @@ public class NotYetBannedIT {
 
 	@TestTemplate
 	@SetAddressStrictness(all = true)
+	@SetAltRegistry(all = true)
 	public void testNoOneIsBanned() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/StrictStrictnessIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/StrictStrictnessIT.java
@@ -28,6 +28,7 @@ import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.it.InjectionInvocationContextProvider;
 import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
 import space.arim.libertybans.it.util.RandomUtil;
 
 import java.util.UUID;
@@ -44,6 +45,7 @@ public class StrictStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness({AddressStrictness.STERN, AddressStrictness.STRICT})
+	@SetAltRegistry(all = true)
 	public void enforceAddressBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 
@@ -78,6 +80,7 @@ public class StrictStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness({AddressStrictness.STERN, AddressStrictness.STRICT})
+	@SetAltRegistry(all = true)
 	public void enforceCompositeBan() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 

--- a/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/UserBanStrictnessIT.java
+++ b/bans-core/src/test/java/space/arim/libertybans/it/test/applicable/UserBanStrictnessIT.java
@@ -27,6 +27,7 @@ import space.arim.libertybans.api.PlayerVictim;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.it.InjectionInvocationContextProvider;
 import space.arim.libertybans.it.SetAddressStrictness;
+import space.arim.libertybans.it.SetAltRegistry;
 import space.arim.libertybans.it.util.RandomUtil;
 
 import java.util.UUID;
@@ -43,6 +44,7 @@ public class UserBanStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness({AddressStrictness.LENIENT, AddressStrictness.NORMAL, AddressStrictness.STERN})
+	@SetAltRegistry(all = true)
 	public void enforceUserBanNormally() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 
@@ -76,6 +78,7 @@ public class UserBanStrictnessIT {
 
 	@TestTemplate
 	@SetAddressStrictness(AddressStrictness.STRICT)
+	@SetAltRegistry(all = true)
 	public void enforceUserBanOnStrict() {
 		NetworkAddress commonAddress = RandomUtil.randomAddress();
 

--- a/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
+++ b/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
@@ -108,7 +108,7 @@ public final class ConnectionListener implements Listener, PlatformListener {
 		InetAddress address = addressReporter.getAddress(player);
 
 		Component message = guardian.checkServerSwitch(
-				player.getUniqueId(), address, event.getTarget().getName()
+				player.getUniqueId(), player.getName(), address, event.getTarget().getName()
 		).join();
 		if (message != null) {
 			event.setCancelled(true);

--- a/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
+++ b/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
@@ -100,8 +100,13 @@ public final class ConnectionListener implements Listener, PlatformListener {
 
 	@EventHandler(priority = EventPriority.HIGH)
 	public void onServerSwitch(ServerConnectEvent event) {
+		if (event.isCancelled()) {
+			logger.trace("Switch {} is already blocked", event);
+			return;
+		}
 		if (event.getReason() == ServerConnectEvent.Reason.LOBBY_FALLBACK) {
 			// Don't kick players if there is no alternative server for them
+			logger.trace("Allowing lobby fallback {}", event);
 			return;
 		}
 		ProxiedPlayer player = event.getPlayer();

--- a/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
+++ b/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
@@ -107,13 +107,14 @@ public final class ConnectionListener implements Listener, PlatformListener {
 		ProxiedPlayer player = event.getPlayer();
 		InetAddress address = addressReporter.getAddress(player);
 
-		Component message = guardian.checkServerSwitch(
+		guardian.checkServerSwitch(
 				player.getUniqueId(), player.getName(), address, event.getTarget().getName()
-		).join();
-		if (message != null) {
-			event.setCancelled(true);
-			audienceRepresenter.toAudience(player).sendMessage(message);
-		}
+		).thenAccept(component -> {
+			if (component != null) {
+				event.setCancelled(true);
+				audienceRepresenter.toAudience(player).sendMessage(component);
+			}
+		});
 	}
 
 }

--- a/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
+++ b/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
@@ -107,14 +107,13 @@ public final class ConnectionListener implements Listener, PlatformListener {
 		ProxiedPlayer player = event.getPlayer();
 		InetAddress address = addressReporter.getAddress(player);
 
-		guardian.checkServerSwitch(
+		Component message = guardian.checkServerSwitch(
 				player.getUniqueId(), player.getName(), address, event.getTarget().getName()
-		).thenAccept(component -> {
-			if (component != null) {
-				event.setCancelled(true);
-				audienceRepresenter.toAudience(player).sendMessage(component);
-			}
-		});
+		).join();
+		if (message != null) {
+			event.setCancelled(true);
+			audienceRepresenter.toAudience(player).sendMessage(message);
+		}
 	}
 
 }

--- a/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
+++ b/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
@@ -68,6 +68,7 @@ public final class ConnectionListener implements PlatformListener {
 			return null;
 		}
 		Player player = event.getPlayer();
+
 		return EventTask.resumeWhenComplete(guardian.executeAndCheckConnection(
 				player.getUniqueId(), player.getUsername(), player.getRemoteAddress().getAddress()
 		).thenAccept((message) -> {
@@ -91,7 +92,8 @@ public final class ConnectionListener implements PlatformListener {
 		}
 		Player player = event.getPlayer();
 		return EventTask.resumeWhenComplete(guardian.checkServerSwitch(
-				player.getUniqueId(), player.getRemoteAddress().getAddress(), destination.getServerInfo().getName()
+				player.getUniqueId(), player.getUsername(), player.getRemoteAddress().getAddress(),
+				destination.getServerInfo().getName()
 		).thenAccept((message) -> {
 			if (message != null) {
 				event.setResult(ServerPreConnectEvent.ServerResult.denied());

--- a/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
+++ b/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
@@ -83,11 +83,13 @@ public final class ConnectionListener implements PlatformListener {
 	@Subscribe(order = PostOrder.EARLY)
 	public EventTask onServerSwitch(ServerPreConnectEvent event) {
 		if (!event.getResult().isAllowed()) {
+			logger.trace("Switch {} is already blocked", event);
 			return null;
 		}
 		RegisteredServer destination = event.getResult().getServer().orElse(null);
 		if (destination == null) {
-			// Properly speaking, the API does not exclude this possibility
+			// Properly speaking, the API does not exclude this possibility. Javadocs do not document it
+			logger.trace("Null destination server {}", event);
 			return null;
 		}
 		Player player = event.getPlayer();

--- a/docs/Network-Installation.md
+++ b/docs/Network-Installation.md
@@ -34,6 +34,18 @@ A few users will seek to install LibertyBans on a limited set of backend servers
 
 If this describes you, please switch **off** the option `platforms.game-servers.use-plugin-messaging` in your config.yml. By turning this feature off, banned players will not be kicked from the entire network, and they will be sent to the lobby instead (as handled by your proxy software).
 
+### Cracked Networks
+
+If you're running a cracked network -- with unauthenticated Minecraft accounts -- you need to be careful that LibertyBans can only "see" fully authenticated users.
+
+By default, LibertyBans records the UUID and IP address of every user who logs in. If LibertyBans is on the proxy and unauthenticated players join the proxy, this can cause a problem leading to false IP bans.
+
+To remedy this, you should use a limbo server. A limbo server is a specific backend server where unauthenticated users go, and they can't leave the limbo server unless logged in.
+
+After setting up a limbo server, you have two options:
+* If running LibertyBans on the proxy, look at the `alts-registry` setting in the config.yml. There, you can ensure that players joining the limbo server won't have their IP addresses recorded.
+* If running LibertyBans on the backend servers, LibertyBans should only be installed on the backend servers where fully authenticated players can join. That is, every server *except* the limbo server.
+
 ### Multiple Proxies
 
 If you're here, you know who you are. Please let us know how LibertyBans suits your needs, where it could use improvement, and if you found or suspect any performance bottlenecks.

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
 					<artifactId>jooq-codegen-maven</artifactId>
 					<version>${jooq.version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-invoker-plugin</artifactId>
+					<configuration>
+						<streamLogsOnFailures>true</streamLogsOnFailures>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
This feature aims to solve a recurrent problem that was stated in the discord server multiples times. 
This problem refers to alts registration for players that haven't logged in, which means that only affects non-premium servers.

In order to solve this, I've added a way to disable alts registration per-server. This means that now you can choose which servers are going to register alts for player and which not.

Despite that, this feature hasn't been tested because I don't have the required time and resources to do it, so I'm opening this pull request in order to make more visible this new version.

So, if you are someone that needs this feature and wants to help, reach me through the libertybans discord server and I can send you the compiled version of it (you can clone this rep and compile it by yourself following the instructions). 