### PR TITLE
Exempt if sender & target has same weight with exemption-luckperms addon

### DIFF
--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/ExemptionLuckPermsConfig.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/ExemptionLuckPermsConfig.java
@@ -21,11 +21,12 @@ package space.arim.libertybans.core.addon.exempt.luckperms;
 
 import space.arim.dazzleconf.annote.ConfComments;
 import space.arim.dazzleconf.annote.ConfDefault;
+import space.arim.dazzleconf.annote.ConfKey;
 import space.arim.libertybans.core.addon.AddonConfig;
 
 public interface ExemptionLuckPermsConfig extends AddonConfig {
-
-    @ConfComments("Whether to exempt punishment if operator & target have the same weight.")
+    @ConfKey("exempt-same")
+    @ConfComments("Whether to exempt victims with the same weight as the operator.")
     @ConfDefault.DefaultBoolean(false)
-    boolean exempt_same();
+    boolean exemptSame();
 }

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/ExemptionLuckPermsConfig.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/ExemptionLuckPermsConfig.java
@@ -19,7 +19,13 @@
 
 package space.arim.libertybans.core.addon.exempt.luckperms;
 
+import space.arim.dazzleconf.annote.ConfComments;
+import space.arim.dazzleconf.annote.ConfDefault;
 import space.arim.libertybans.core.addon.AddonConfig;
 
 public interface ExemptionLuckPermsConfig extends AddonConfig {
+
+    @ConfComments("Whether to exempt punishment if operator & target have the same weight.")
+    @ConfDefault.DefaultBoolean(false)
+    boolean exempt_same();
 }

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
@@ -73,7 +73,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 		return userManager.loadUser(senderUuid).thenCombine(userManager.loadUser(targetUuid), (senderUser, targetUser) -> {
 			int senderWeight = calculateUserMaxWeight(senderUser);
 			int targetWeight = calculateUserMaxWeight(targetUser);
-			return targetWeight > senderWeight;
+			return targetWeight >= senderWeight;
 		});
 	}
 

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
@@ -74,7 +74,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 			int senderWeight = calculateUserMaxWeight(senderUser);
 			int targetWeight = calculateUserMaxWeight(targetUser);
 			if (senderWeight == -1 && targetWeight == -1) return false;
-			return targetWeight >= senderWeight;
+			return addon.config().exempt_same() ? targetWeight >= senderWeight : targetWeight > senderWeight;
 		});
 	}
 

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
@@ -79,7 +79,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 	}
 
 	private int calculateUserMaxWeight(User user) {
-		int maxWeight = 0;
+		int maxWeight = -1;
 		for (Group group : user.getInheritedGroups(user.getQueryOptions())) {
 			int weight = group.getWeight().orElse(-1);
 			if (weight > maxWeight) {

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
@@ -74,7 +74,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 			int senderWeight = calculateUserMaxWeight(senderUser);
 			int targetWeight = calculateUserMaxWeight(targetUser);
 			if (senderWeight == -1 && targetWeight == -1) return false;
-			return addon.config().exempt_same() ? targetWeight >= senderWeight : targetWeight > senderWeight;
+			return addon.config().exemptSame() ? targetWeight >= senderWeight : targetWeight > senderWeight;
 		});
 	}
 

--- a/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
+++ b/bans-core-addons/exemption-luckperms/src/main/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProvider.java
@@ -73,6 +73,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 		return userManager.loadUser(senderUuid).thenCombine(userManager.loadUser(targetUuid), (senderUser, targetUser) -> {
 			int senderWeight = calculateUserMaxWeight(senderUser);
 			int targetWeight = calculateUserMaxWeight(targetUser);
+			if (senderWeight == -1 && targetWeight == -1) return false;
 			return targetWeight >= senderWeight;
 		});
 	}
@@ -80,7 +81,7 @@ public final class LuckPermsExemptProvider implements ExemptProvider {
 	private int calculateUserMaxWeight(User user) {
 		int maxWeight = 0;
 		for (Group group : user.getInheritedGroups(user.getQueryOptions())) {
-			int weight = group.getWeight().orElse(0);
+			int weight = group.getWeight().orElse(-1);
 			if (weight > maxWeight) {
 				maxWeight = weight;
 			}

--- a/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
+++ b/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
@@ -131,11 +131,4 @@ public class LuckPermsExemptProviderTest {
 		assertIsExempted(true);
 	}
 
-	@Test
-	public void targetAndOperatorHaveNoWeight() {
-		setGroups(senderUser, null, null);
-		setGroups(targetUser, null, null);
-		assertIsExempted(false);
-	}
-
 }

--- a/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
+++ b/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
@@ -124,4 +124,18 @@ public class LuckPermsExemptProviderTest {
 		assertIsExempted(false);
 	}
 
+	@Test
+	public void targetHasExemptWeightSameAsOperatorWeight() {
+		setGroups(senderUser, null, null, 4, null, null, 5, 20);
+		setGroups(targetUser, 3, null, 10, null, 20, 9);
+		assertIsExempted(true);
+	}
+
+	@Test
+	public void targetAndOperatorHaveNoWeight() {
+		setGroups(senderUser, null, null);
+		setGroups(targetUser, null, null);
+		assertIsExempted(false);
+	}
+
 }

--- a/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
+++ b/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
@@ -24,8 +24,7 @@ import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.model.user.UserManager;
 import net.luckperms.api.query.QueryOptions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,6 +52,7 @@ public class LuckPermsExemptProviderTest {
 	private UUID targetUuid;
 	private User senderUser;
 	private User targetUser;
+	private ExemptionLuckPermsConfig config;
 	private LuckPermsExemptProvider exemptProvider;
 
 	public LuckPermsExemptProviderTest(@Mock ExemptionLuckPermsAddon addon) {
@@ -68,6 +68,7 @@ public class LuckPermsExemptProviderTest {
 		this.senderUser = senderUser;
 		this.targetUser = targetUser;
 		when(config.enable()).thenReturn(true);
+		this.config = config;
 		when(addon.config()).thenReturn(config);
 		when(addon.luckPerms()).thenReturn(luckPerms);
 		when(luckPerms.getUserManager()).thenReturn(userManager);
@@ -128,6 +129,14 @@ public class LuckPermsExemptProviderTest {
 	public void targetHasExemptWeightSameAsOperatorWeight() {
 		setGroups(senderUser, null, null, 4, null, null, 5, 20);
 		setGroups(targetUser, 3, null, 10, null, 20, 9);
+		assertIsExempted(false);
+	}
+
+	@Test
+	public void targetHasExemptWeightSameAsOperatorWeightOptionEnabled() {
+		setGroups(senderUser, null, null, 4, null, null, 5, 20);
+		setGroups(targetUser, 3, null, 10, null, 20, 9);
+		when(config.exempt_same()).thenReturn(true);
 		assertIsExempted(true);
 	}
 

--- a/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
+++ b/bans-core-addons/exemption-luckperms/src/test/java/space/arim/libertybans/core/addon/exempt/luckperms/LuckPermsExemptProviderTest.java
@@ -136,7 +136,7 @@ public class LuckPermsExemptProviderTest {
 	public void targetHasExemptWeightSameAsOperatorWeightOptionEnabled() {
 		setGroups(senderUser, null, null, 4, null, null, 5, 20);
 		setGroups(targetUser, 3, null, 10, null, 20, 9);
-		when(config.exempt_same()).thenReturn(true);
+		when(config.exemptSame()).thenReturn(true);
 		assertIsExempted(true);
 	}
 


### PR DESCRIPTION
In most cases, An admin should not be able to punish another admin.