### PR TITLE
Add note about User support for LiteBans

### DIFF
--- a/docs/Comparison-to-LiteBans.md
+++ b/docs/Comparison-to-LiteBans.md
@@ -61,6 +61,12 @@ LiteBans is also behind a pay-wall, meaning that users have to pay in order to u
 
 Users of LiteBans must carefully consider whether they are willing to rely entirely on the author of LiteBans for features and improvements.
 
+### Support
+
+Support for LibertyBans is provided GitHub and a text channel on a Discord Server.
+
+LiteBans primarely offers support through Discord, however, only does so for users who verified their purchase of the plugin. This also includes requesting support for their API, meaning if you're not a customer of their plugin, chances are low you will gain access to their support server, or receive help with their API at all.
+
 ### Versioning
 
 LiteBans does not follow semantic versioning, leading to potential instability for developers using its API. It has introduced new API without issuing a minor release.<sup id="note2ret">[2](#note2)</sup>

--- a/docs/Comparison-to-LiteBans.md
+++ b/docs/Comparison-to-LiteBans.md
@@ -63,7 +63,7 @@ Users of LiteBans must carefully consider whether they are willing to rely entir
 
 ### Support
 
-Support for LibertyBans is provided GitHub and a text channel on a Discord Server.
+Support for LibertyBans is provided through GitHub Issues and a dedicated text channel on a Discord Server.
 
 LiteBans primarely offers support through Discord, however, only does so for users who verified their purchase of the plugin. This also includes requesting support for their API, meaning if you're not a customer of their plugin, chances are low you will gain access to their support server, or receive help with their API at all.
 

--- a/docs/Comparison-to-LiteBans.md
+++ b/docs/Comparison-to-LiteBans.md
@@ -65,7 +65,7 @@ Users of LiteBans must carefully consider whether they are willing to rely entir
 
 Support for LibertyBans is provided through GitHub Issues and a dedicated text channel on a Discord Server.
 
-LiteBans primarely offers support through Discord, however, only does so for users who verified their purchase of the plugin. This also includes requesting support for their API, meaning if you're not a customer of their plugin, chances are low you will gain access to their support server, or receive help with their API at all.
+LiteBans primarily offers support through Discord; however, it only does so for users who verified their purchase of the plugin. This also includes requesting support for their API, meaning if you're not a customer of their plugin, chances are low you will gain access to their support server, or receive help with their API at all.
 
 ### Versioning
 


### PR DESCRIPTION
LiteBans does not have the best way of support, requiring authentication of purchase to gain access to their main source of support (Their Discord server). This extends to API support too.

I assume LibertyBans provides support through issues on GitHub? If not can I alter it.