### PR TITLE
Update repository url(s).

### DIFF
--- a/bans-core/src/main/resources/contributors
+++ b/bans-core/src/main/resources/contributors
@@ -25,6 +25,7 @@ szyha
 AGI
 Arceus
 Athar42
+Agent
 Boy0000
 BumbleTree
 copyandexecute
@@ -47,5 +48,6 @@ PasteDev
 pwnker
 RhythmicSys
 SleepingTea
+SeemWind
 tommasobenatti
 VanironCZ

--- a/bans-env/bungeeplugin/src/it/waterfall-slf4j/pom.xml
+++ b/bans-env/bungeeplugin/src/it/waterfall-slf4j/pom.xml
@@ -107,7 +107,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 </project>

--- a/bans-env/spigotplugin/src/it/paper-adventure/pom.xml
+++ b/bans-env/spigotplugin/src/it/paper-adventure/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.5-R0.1-20210616.205716-355</version>
+            <version>1.16.5-R0.1-20210721.014705-360</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -107,7 +107,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 </project>

--- a/bans-env/spigotplugin/src/it/paper-slf4j/pom.xml
+++ b/bans-env/spigotplugin/src/it/paper-slf4j/pom.xml
@@ -107,7 +107,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
The PaperMC team announced an API url change a while ago, but it seems the old url recently stopped working. This PR updates LibertyBans to use the new url for platform environment specific testing, as well as adds new contributors!