### PR TITLE
Transalte basic doc pages into Chinese

### DIFF
--- a/bans-core/src/main/resources/lang/messages_zh_cn.yml
+++ b/bans-core/src/main/resources/lang/messages_zh_cn.yml
@@ -1,5 +1,5 @@
  # 
- # 信息配置文件
+ # 消息配置文件
  # 
  # 
  # 在大多数情况下，默认消息中的变量是可用的
@@ -263,7 +263,7 @@ alts:
 
 admin:
   restarted: '&a已重启插件'
-  no-permission: '&c抱歉，您没有权限怎么做。'
+  no-permission: '&c抱歉，您没有权限这么做。'
   reloaded: '&a已重载插件'
   ellipses: '&a...'
   importing:

--- a/docs/zh-cn/Addons.md
+++ b/docs/zh-cn/Addons.md
@@ -1,0 +1,125 @@
+
+LibertyBans provides several additional features in the form of addons.
+
+There is no performance cost or other overhead from installing addons -- they hook directly into the main LibertyBans core with no intermediaries. Placing a feature into an addon is a design decision to keep the plugin maintainable.
+
+## Installing Addons
+
+1. Download the addon jar: [All addons may be downloaded here](https://ci.hahota.net/job/LibertyBans/).
+2. Place the addon jar in the `addons` directory of the LibertyBans plugin folder.
+3. Restart the server.
+
+The number of installed addons is displayed at startup:
+```
+[LibertyBans] Detected 2 addon(s)
+```
+
+## Configuring and Managing Addons
+
+Addon configuration is located in the same place as the installed addon jars -- the `addons` directory of the LibertyBans plugin folder.
+
+After configuring an addon, run `/libertybans reload`.
+
+Related commands:
+* `/libertybans addon list` - Lists installed addons.
+* `/libertybans addon reload <addon identifier` - Reloads the configuration of a single addon only.
+
+# Available Addons
+
+## New Commands
+
+### CheckPunish
+
+This addon provides the `/libertybans checkpunish <ID>` command. This command displays the details of a specific punishment given the punishment ID.
+
+Requires the permission `libertybans.addon.checkpunish.use`.
+
+### CheckUser
+
+Provides the `/libertybans checkuser <player>` command. This command displays if the given player is banned or muted.
+
+Requires the permission `libertybans.addon.checkuser.use`.
+
+### StaffRollback
+
+Provides the `/libertybans staffrollback <operator> [time]` command. Performing a rollback fully purges all punishments by a certain staff member, which is useful if a staff member becomes rogue or has their account hacked.
+
+The `[time]` argument identifies how long ago punishments should be purged. Punishments made earlier than the given amount of time ago are kept.
+
+**WARNING: Purged punishments are NOT recoverable.**
+
+Requires the permission `libertybans.addon.staffrollback.use`.
+
+## Exemption
+
+Exemption functionality allows you to protect certain players from punishment. For example, you may want to prevent moderators from banning administrators, and you never want the owner to be banned.
+
+LibertyBans allows you to achieve this. You can configure exemption so that owners can ban admins, and admins can ban moderators, but moderators cannot ban admins.
+
+Because there is no unified permissions API, LibertyBans requires you to choose and install an exemption backend for this feature to operate:
+
+1. LuckPerms group weights
+2. Vault permissions
+
+Notes:
+* The denial message when a staff member tries to punish a superior officer is configurable in the messages.yml file.
+* IP-based punishments do not consider exemption. The exemption feature works best with user and composite punishments.
+* Granting exemption to a user after the fact will not automatically undo existing punishments.
+
+### Exemption (LuckPerms group weights)
+
+This addon works only with LuckPerms, since it leverages LuckPerms' group weights feature.
+
+Configuration is simple. Make sure to configure LuckPerms' group weights. Higher staff ranks should have bigger weights.
+
+An operator can punish a player if the target player has a lower group weight than the operator. Note that LibertyBans considers every group for each user to determine the user's highest group weight.
+
+### Exemption (Vault permissions)
+
+This addon provides exemption functionality using tiered permissions. It requires a Vault-compatible permissions plugin and only supports Spigot/Paper servers.
+
+The addon operates by defining exemption levels. The higher the exemption level, the more privileged the staff member. Staff members with a lower exemption level cannot punish staff members with a higher level.
+
+Configuration:
+1. Grant the permission `libertybans.<type>.exempt.level.<level>` . 
+2. Set the `max-level-to-scan-for` to the value of the highest exemption level you granted.
+3. Change the `permission-check-thread-context` value to suit your permissions plugin.
+
+## Layouts
+
+The layouts addon provides the `/libertybans punish` command. It is a straightforward yet powerful means of defining punishment templates, ladders, tracks -- however you want to call them.
+
+After a punishment is created via a layout track, it is treated like any other punishment. However, of course, new punishments created using the same track will apply a configured ladder to calculate punishment details.
+
+### Configuration
+
+The configuration works by defining a ladder for each layout track. Each entry on the ladder specifies the punishment to be applied when a player reaches that many (or more) punishments.
+
+### Permission
+
+Permissions to use layouts are similar for permissions to create punishments normally. However, permissions are specific to each layout. Replace `<track>` with the name of the layout track you want to grant permission for.
+
+* `libertybans.addon.layout.use.<track>.target.uuid` - punish players
+* `libertybans.addon.layout.use.<track>.target.ip` - punish IP addresses
+* `libertybans.addon.layout.use.<track>.target.both` - punish player and IP address in the same punishment
+* `libertybans.addon.layout.use.<track>.silent` - use the silent feature
+
+Please note that the notification permissions remain tied to the punishment type. In other words, the permissions `libertybans.<type>.<do|undo>.<notify|notifysilent>` remain the same; there are no notification permissions specifically for layouts.
+
+### Interaction with Exemption Permissions
+
+If you are using the Vault permissions exemption addon, then the `libertybans.layout.exempt.level.<level>` permission defines exemption levels. (The typical permission cannot be used because exemption is checked before the punishment is executed).
+
+## Other
+
+### Shortcut Reasons
+
+Allows substituting faster shortcuts for commonly-used punishment reasons. For example, `/ban A248 30d #hacking` becomes `/ban A248 30d You are banned for hacking`.
+
+Configuration is straight-forward otherwise. If a staff member specifies an invalid shortcut, the command is denied to prevent mistakes. Shortcuts are case-sensitive.
+
+### Warn Actions
+
+Allows executing actions, such as executing commands or inflicting additional punishments, when a certain amount of warns is reached.
+
+This addon is relatively easy to use and configure.

--- a/docs/zh-cn/Blocking-Alt-Accounts.md
+++ b/docs/zh-cn/Blocking-Alt-Accounts.md
@@ -1,0 +1,36 @@
+
+LibertyBans offers a variety of tools to prevent alt accounts from circumventing punishment.
+
+Some of them are automatic; some require manual action by staff members. They differ in sophistication and complexity. Some measures may result in blocking legitimate players. Therefore, it is important to understand the tools at your disposal and the implications of their use.
+
+## IP-based punishments
+
+A punishment can apply to an IP address. However, LibertyBans takes this feature further than competing punishment plugins by considering past IP addresses and discovering the network of associated alt accounts.
+
+See [Punishment Enforcement](Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings) for more information.
+
+## Composite punishments
+
+A composite punishment applies to a UUID and an IP address. Rather than create two separate punishments, a composite punishment is a "two-in-one" punishment.
+
+The co-location of UUID and IP address also makes composite punishments easier to track on a per-user basis.
+* If you typically punishment IP addresses by default, consider using composite punishments instead.
+* If you want to treat user punishments like IP-based punishments, consider composite punishments.
+
+The idea is simple and effective but there are caveats. See [Guide to Composite Punishments](Guide-to-Composite-Punishments).
+
+## Alt Checks
+
+LibertyBans can perform manual alt-checks when requested by staff members, via the `/libertybans alts` command.
+
+Additionally, an alt-check can be run automatically when a player joins. The "auto-show" feature does this -- every time a player joins, LibertyBans will run an alt check on them:
+  * This feature is fully configurable.
+  * For example, it is possible to notify staff members when the alt account of a banned player joins. This feature is fully configurable.
+
+## Connection Limiter
+
+There is a very basic connection limiter. If enabled, too many players joining on the same IP address within a certain time period will trigger the limit.
+
+For example, if more than 5 players join from the same IP address within the past 10 minutes, no more joins will be allowed from that IP address.
+
+This can help with bot attacks although is not a complete solution.

--- a/docs/zh-cn/Changes-in-LibertyBans-1.0.0.md
+++ b/docs/zh-cn/Changes-in-LibertyBans-1.0.0.md
@@ -1,0 +1,61 @@
+
+This is a formal change-log of changes made in LibertyBans 1.0.0. It notes all manners of changes, including breaking changes; technically-detailed, little-mentioned changes which are invisible to the user; sweeping feature additions, and in-depth descriptions thereof; design and architectural decisions, and various minor matters.
+
+If you are interested in a guide for upgrading to LibertyBans 0.8.x to 1.0.0, which focuses on breaking changes and their impact to you, see [this page](Upgrading-to-LibertyBans-1.0.0-from-0.8.x)
+
+## Changes
+
+* Permissions have been refactored and made into a logically intuitive pattern.
+* Permission messages have been re-organized using `PunishmentPermissionSection`, which is used consistently for each punishment type with regard to punishment additions and removals.
+* Compatibility is removed with a bugged duration permissions format from LibertyBans 0.7.6
+* MariaDB 10.2 and MySQL 5.7 are no longer supported.
+* The `playerOrAddress` option in the messages.yml is now `player-or-address`, `permission.command` is now `permission.uuid` in several places, and `banList` and `muteList` become `ban-list` and `mute-list`
+* The schema history for 1.0.0 is made anew, so older versions like 0.8.2 will fail to use the new database. To ensure seamless transition of existing data, a Java-based Flyway migration will exist in LibertyBans 1.0.0, which will detect existing 0.8.2 tables and transfer their data to the new tables. The Java-based migration will be removed in LibertyBans 1.1.0; Java-based migrations do not use checksums in the same manner as normal Flyway migrations.
+* All SQL queries are rewritten to use JOOQ. The build runs JOOQ's code generation. This change enables PostgreSQL compatibility, as queries previously used back-ticks.
+* Integration tests now start instances of PostgreSQL in addition to MariaDB.
+* Flyway is updated to 8.x
+* The event scheduler feature for MySQL/MariaDB has been removed. Its marginal benefit does not justify the maintenance cost.
+* Added accepted value 'MYSQL' for `rdms-vendor` and require MySQL to be distinguished from MariaDB.
+* LibertyBans now handles transaction serialization failure and will retry transactions which failed due to contention:
+  * Serialization failure describes the situation where multiple database transactions operate on the same data, and somehow conflict with one another. Serialization failures are propagated to the application.
+  * Whether software handles serialization failure has nothing to do with whether it maintains the integrity of its data: it is not possible to corrupt data merely due to a serialization failure.
+  * This means, in rare cases where running a command would result in a serialization failure, LibertyBans 1.0.0 will handle the situation gracefully, whereas LibertyBans 0.8.x will fail with an exception. Symptoms in 0.8.x would include stacktraces in the server console. However, in practice, no one has reported any instance of serialization failure in LibertyBans.
+  * The handling of transaction serialization failure will not be back-ported to LibertyBans 0.8.x. Much software does not handle transaction serialization failure (including LibertyBans 0.8.x) therefore this is not considered a bug of sufficient importance.
+  * Further technical reading: https://stackoverflow.com/questions/7705273/what-are-the-conditions-for-encountering-a-serialization-failure
+* Relevant client encoding variables are set per each database upon establishing connection. Also, the charset utf8mb4 and collation utf8mb4_bin are now set on created tables for MariaDB and MySQL.
+* Added the composite victim type, a new kind of victim which is both a UUID and address.
+  * Composite victims are a better choice when you want to IP-ban users by default, but do not want the technical intricacies associated with banning an IP address rather than a user. In other words, you want user bans to be enforced as IP-bans but be able to punish, unpunish, and list punishments as if you were doing so for a user rather than an IP address.
+  * See the wiki page on composite punishments for more details.
+* The /accounthistory command accepts the `-both` argument to show the accounts matching the specified user's UUID or current IP address.
+* HikariCP is now relocated in release builds.
+* New variables are added to punishment messages:
+  * %TYPE_VERB% - verb-based rendition of the punishment type
+  * %TIME_PASSED_SIMPLE% - like TIME_PASSED but rounds to the largest time unit
+  * %TIME_REMAINING_SIMPLE% - like TIME_REMAINING but rounds to the largest time unit
+  * %HAS_EXPIRED% - whether the punishment has expired on account of the passage of time
+* Added the %PREVIOUSPAGE% variable
+
+### API Changes
+
+* The API now uses `long` (64-bit integers) for punishment IDs. To migrate usage, cast to long or refactor to use long IDs.
+  * `getID` is deprecated but kept for backwards compatibility. Please migrate to `getIdentifier` when possible.
+* `EnforcementOptions` has been added to the API and replaces some methods in DraftPunishment, Punishment, and RevocationOrder. If you were using any of the 'withoutEnforcement' or 'withoutUnenforcement' methods, you will need to change your code. Usage can be replaced as follows:
+  * For DraftPunishment: `draftPunishment.enactPunishmentWithoutEnforcement()` -> `draftPunishment.enactPunishment(EnforcementOptions.builder().enforcement(Enforcement.NONE).build())`
+  * For Punishment:
+    * `punishment.undoPunishmentWithoutUnenforcement()` -> `punishment.undoPunishment(EnforcementOptions.builder().enforcement(Enforcement.NONE).build)`
+    * `punishment.unenforcePunishment()` -> `punishment.unenforcePunishment
+  * For RevocationOrder:
+    * `revocationOrder.undoPunishmentWithoutUnenforcement()` -> `revocationOrder.undoPunishment(EnforcementOptions.builder().enforcement(Enforcement.NONE).build())`
+    * `revocationOrder.undoAndGetPunishmentWithoutUnenforcement()` -> `revocationOrder.undoAndGetPunishment(EnforcementOptions.builder().enforcement(Enforcement.NONE).build())`
+* The package `space.arim.libertybans.api.revoke` has been merged into `space.arim.libertybans.api.punish`. Imports should be updated accordingly.
+* The API for selecting punishments has been expanded in capability. Keyset pagination is now possible. As part of this change, `SelectionOrderBuilder` and `SelectionOrder` have breaking changes:
+  * `SelectionOrderBuilder#maximumToRetrieve` has been removed, in favor of `#limitToRetrieve` which is consistent with SQL's LIMIT.
+* Non-breaking improvements to `PunishmentRevoker`:
+  * The requirement that the punishment type be singular (PunishmentType.isSingular()) is lifted for `PunishmentRevoker#revokeByTypeAndVictim`. However, if a non-singular punishment type is used, it is unspecified behavior as to which punishment will be revoked.
+  * Added the method `PunishmentRevoker#revokeByTypeAndPossibleVictims`.
+* Other breaking changes are only relevant if you were implementing the API yourself, which is unlikely:
+  * Getter methods on `SelectionOrder` reflect the new and expanded API.
+  * Getter methods on `RevocationOrder` reflect the expanded API.
+* The Punishment.PERMANENT_END_DATE constant is added to the API.
+* It is now possible to dispatch "silent" punishments using the API.
+* Added `PunishmentFormatter#formatPunishmentTypeVerb`

--- a/docs/zh-cn/Changes-in-LibertyBans-1.1.0.md
+++ b/docs/zh-cn/Changes-in-LibertyBans-1.1.0.md
@@ -1,0 +1,27 @@
+
+## Changes
+
+* Require Java 17.
+* Using MariaDB with LibertyBans now requires MariaDB 10.6 at minimum.
+* Automatic detection of Geyser/Floodgate and determination of the Bedrock name prefix.
+  * The `GEYSER` server-type option has been removed. This server type was inflexible; it failed to distinguish between online and offline Geyser-utilizing servers. It is obsolete due to automatic Floodgate detection.
+  * The name prefix is queried from the Floodgate API at startup.
+* Before this release, `STRICT` address-strictness enforced user punishments too stringently - as if they were IP-based punishments - which was contrary to the documentation.
+  * Because it is impossible to retroactively change the behavior of `STRICT` without breaking existing setups, a new address-strictness setting `STERN` is added. `STERN` behaves the way `STRICT` was previously documented to.
+  * The `STRICT` documentation has updated to reflect its full behavior.
+  * See the wiki page for more information.
+* Added the exemption feature. To support exemption flexibly, different exemption backends are offered:
+  * The `exemption-luckperms` addon depends on LuckPerms and uses LuckPerms' group weights to define the exemption hierarchy.
+  * The `exemption-vault` addon depends on Vault and works only on Bukkit. It uses tiered permissions to define exemption levels.
+  * If their dependencies are not met, or if they are installed on the wrong platform, these addons will not load.
+  * See the wiki for documentation on this feature.
+* In the rare case that multiple mutes are issued very quickly, the `warn-actions` addon will make sure warns do not "overlap" one another. There were no reports of this happening, but it was a theoretical possibility. The solution works by leveraging the newly-added `seekBefore` API.
+* Snapshot versions are now differentiated according to the build timestamp.
+* The database-related thread pool is now fully shut down and its termination awaited before the connection pool is closed. This prevents a harmless exception which occurred when shutdown coincided with the periodic synchronization task.
+
+### API Changes
+
+* Expand selection capabilities:
+  * `SelectionOrder#countNumberOfPunishments` yields the pure number of punishments, which is more efficient than retrieving the punishments themselves from the database.
+  * `SelectionOrderBuilder#seekBefore` allows retrieving punishments before a specified time / ID. It is the counterpart of the existing method `SelectionOrderBuilder#seekAfter`.
+  * A selection order may filter by victim types, not just victims.

--- a/docs/zh-cn/Color-Codes.md
+++ b/docs/zh-cn/Color-Codes.md
@@ -1,0 +1,37 @@
+All chat messages may use color codes, enabling fancier formatting.
+
+## How To
+
+All color codes start with '&'. You can put color codes in your messages like this:
+`<color code><text>`
+You can use multiple color codes and formatting.
+
+## All Codes
+
+![Color Codes Image](https://user-images.githubusercontent.com/22414680/183296891-9882b41d-3c64-40b0-ba06-3752e590efe5.png)
+
+The &k color code is called *obfuscated* (a.k.a *magic*). It scrambles the text which it formats.
+
+## Hex Color Codes
+
+You can use hex colour codes in messages with the syntax <#00FF00>
+
+If the platform does not support it, hex color codes are converted to the closest '&' color codes.
+
+Platforms supporting hex color codes:
+
+* Paper *1.16 or later*
+* BungeeCord
+* Velocity
+
+## Example
+
+These 3 messages:
+```
+&61. Be kind to your fellow players.
+&b2. No griefing.
+&d3. No swearing.
+```
+Result in:
+
+![Result_image](https://gamepedia.cursecdn.com/wiki_bukkit/thumb/9/9c/HelpYmlGeneralTopic.png/450px-HelpYmlGeneralTopic.png?version=9f7895b8f7c02bbcd2d23733fa7e5653)

--- a/docs/zh-cn/Commands.md
+++ b/docs/zh-cn/Commands.md
@@ -1,0 +1,45 @@
+
+This page describes how to change command aliases. This can be used to rename commands, for example.
+
+## Layout
+
+Every command can be run with `/libertybans <cmd>`.
+
+For example, writing `/ban` is equivalent to `/libertybans ban` under the default installation.
+
+## Disabling Built-In Aliases
+
+By default, LibertyBans registers aliases for commonly-used commands, as defined in the config.yml:
+
+```yaml
+# ...
+commands:
+  aliases:
+    - "ban" # /ban -> /libertybans ban
+    - "ipban" # /ipban -> /libertybans ipban
+    # etc.
+```
+
+You can remove any aliases which you do not want.
+
+## Creating New Aliases
+
+LibertyBans is a punishment plugin, not an alias plugin. To define your own aliases, you should use another plugin which is made for the task.
+
+### Bukkit
+
+On Bukkit, you don't need to install another plugin.
+
+Every Bukkit server has a file called the `commands.yml` which allows you to control command aliases. This file is very powerful and will help you customize your server's vast array of commands.
+
+### BungeeCord
+
+On BungeeCord you should find a plugin which allows you to create command aliases.
+
+We know of multiple plugins in existence to do this.
+
+### Velocity
+
+We do not currently know of any command alias plugins for Velocity that are updated for Velocity 3.x
+
+The plugin [Aliasr](https://github.com/tobi406/aliasr) exists, but was made for Velocity 1.x and has not been updated. We suggest that you find a developer to update this plugin to Velocity 3.x -- it wouldn't  be very difficult considering Aliasr is a very small plugin and it would be trivial to update it to Velocity 3.x

--- a/docs/zh-cn/Comparison-to-AdvancedBan.md
+++ b/docs/zh-cn/Comparison-to-AdvancedBan.md
@@ -1,0 +1,234 @@
+
+This is intended to be an impartial analysis of the API, design, and implementation of AdvancedBan compared to LibertyBans.
+
+I (A248) am both the creator of LibertyBans and one of the lead contributors to AdvancedBan. Although I am not unbiased, I rely on my familiarity with both codebases to conduct an in-depth analysis.
+
+## Design
+
+### Singleton Managers
+
+AdvancedBan's codebase is heavily oriented toward singletons. This design decision leads to very fragile initialization. In the past, there have been issues where another plugin referenced AdvancedBan's classes and initialized them prematurely.<sup id="note1ret">[1](#note1)</sup>
+
+LibertyBans is fully instance-based, which means another plugin referencing its classes will not cause initialization conflicts.
+
+### IDs
+
+AdvancedBan has a quirk where it creates two IDs for every punishment - one ID for the active punishment and another ID for the punishment in history.
+
+This is quite counter-intuitive. Having two separate punishment IDs can lead to confusion with appeals systems and variables in message configuration.
+
+This finding was so unexpected that some of the core contributors to AdvancedBan were not aware of it and were surprised to hear about it.<sup id="note2ret">[2](#note2)</sup>
+
+### Operator UUIDs
+
+AdvancedBan stores operator names, but not UUIDs. If a server operator changes their name, AdvancedBan will continue to display the old name in punishment messages.
+
+LibertyBans stores the operator UUID and displays the most recently-known name.<sup id="note3ret">[3](#note3)</sup>
+
+### Database Schema
+
+AdvancedBan uses VARCHAR columns for storing UUIDs and IP addresses. This is equivalent to storing the string representation of UUIDs and IP addresses. In contrast, LibertyBans uses BINARY column types in order to reduce storage space. The actual difference is small, but not negligible.
+
+### Timezones
+
+AdvancedBan stores the timezone offset as part of the timestamp in the database. This is somewhat clunky, and it requires that users of the AdvancedBan API carefully follow suit with this little-documented behavior.
+
+LibertyBans uses UTC time in the database. When displaying a punishment, it uses the configured timezone.
+
+Consequently, if you change the configured timezone in LibertyBans, all punishments will transparently update their displayed time. In AdvancedBan, however, the time will not be updated to the new timezone.
+
+## Implementation
+
+### Caching
+
+AdvancedBan uses a hand-rolled punishment cache. This cache is quite brittle and has resulted in several bugs. It is populated and invalidated manually. Users ocassionally report issues with cached punishments failing to be invalidated.
+
+LibertyBans caches only mutes, and nothing else. It uses a caching library. No bugs to date (as of 21 Dec 2021) have been observed with the caching mechanism used by LibertyBans.
+
+### Transactional Consistency
+
+AdvancedBan does not rely on transactional consistency like LibertyBans does. In practice, this means certain conditions can be violated in certain circumstances in AdvancedBan - this is a bug in AdvancedBan's design, and it is not a simple fix.
+
+In both AdvancedBan and Liberty*Bans, attempting to ban a player already banned results in a message affirming such. If you try to ban another player twice, AdvancedBan will tell you "this player is already banned." However, this guarantee does not hold solid. If you are somehow able to execute /ban quickly enough twice, you can successfully ban another player twice.<sup id="note4ret">[4](#note4)</sup>
+
+Although it may sound far-fetched to ban a player twice quickly, it has been observed multiple times in practice. Automated punishment mechanisms, such as anticheats, are prone to issue commands very quickly, as they are not limited by human typing speed.
+
+This bug in AdvancedBan used to be one reason users of LibertyBans who had imported from AdvancedBan would observe duplicate punishments. In contrast to AdvancedBan, LibertyBans makes full use of transactional consistency, and is therefore not subjet to the described AdvancedBan bug.
+
+### Synchronous / Asynchronous Constructs
+
+Unlike in popular myth, threads are not cheap. At present, a thread in Java is a 1-to-1 mapping of an OS thread, which requires significant resources. A wise program avoids context switches for small workloads, since the overhead of multithreaded execution would exceed the gains of using multiple cores.
+
+The AdvancedBan internals and API are synchronously designed. As a result, AdvancedBan necessarily spawns a new threaded task for most operations. This leads to increased context switching and resource consumption.
+
+LibertyBan's asynchronous design has a few advantages. Threads are created as necessary and in accordance with the workload. This is much more lightweight and scalable.
+
+As a another consequence, it is easier for developers of AdvancedBan to accidentally introduce bugs. Specifically, it becomes easier to call a heavy operation on the main thread. Indeed, AdvancedBan will perform a query on the main thread in limited circumstances.<sup id="note5ret">[5](#note5)</sup>
+
+Note that *synchronous*, in this context, does **not** mean "on the main thread". Asynchronous does **not** mean multithreaded. I suggest reading [this StackOverflow answer](https://stackoverflow.com/a/748235/).
+
+### Thread safety
+
+Parts of AdvancedBan's code are not thread safe. This has lead to many subtle bugs, which are still plaguing AdvancedBan.<sup id="note6ret">[6](#note6)</sup> Moreover, AdvancedBan does not place much of an emphasis on synchronisation.<sup id="note7ret">[7](#note7)</sup>
+
+In LibertyBans, there have never been any known synchronisation issues to-date.
+
+### Connection Pooling
+
+AdvancedBan depends on HikariCP since version 2.1.9, so it looks like it uses a connection pool. However, in reality, internal synchronization in AdvancedBan prevents it from taking advantage of the additional connections. Unfortunately, this is not so easy to solve on AdvancedBan's side. That same synchronization is critical for preventing other thread safety problems.<sup id="note8ret">[8](#note8)</sup>
+
+LibertyBans uses HikariCP and takes advantage of it.
+
+### UTF-8 Encoding
+
+AdvancedBan has historically suffered with UTF-8 support, and the current AdvancedBan codebase still uses the default encoding in some places, which suggests there are still lurking issues. UTF-8 has been problematic in config files as well as database definitions. References: 
+ * https://www.spigotmc.org/resources/advancedban.8695/update?update=327430 
+ * https://www.spigotmc.org/resources/advancedban.8695/update?update=228946
+ * https://github.com/DevLeoko/AdvancedBan/issues/433
+ * https://github.com/DevLeoko/AdvancedBan/issues/430
+ * https://github.com/DevLeoko/AdvancedBan/issues/202
+ * https://github.com/DevLeoko/AdvancedBan/issues/74
+
+LibertyBans is made with full Unicode support in mind.
+
+### API Documentation
+
+The AdvancedBan API is significantly under-documented. This makes it time-consuming for other developers to use the AdvancedBan API, as they need to discover the meaning and details of API methods by looking at the implementation or asking for support. Details such as nullability and contractual guarantees are wholly missing from the AdvancedBan API documentation.
+
+The lack of a clear API specification in AdvancedBan also leads to incorrect assumptions: by relying on certain implementation details, external code becomes reliant on specific behavior which the author of AdvancedBan may not have intended such behavior to be guaranteed. In turn, this means that a future update of AdvancedBan may inadvertently break plugins which depended on the specific internal behavior.
+
+In contrast, the LibertyBans API is fully documented using javadocs. This makes it easy for other developers to learn and use the LibertyBans API. Method expectations, contracts, and guarantees are clearly stated and explained.
+
+## Philosophy
+
+### Versioning Policy
+
+LibertyBans follows strict semantic versioning. This means that updates a single major release (e.g. 1.x or 2.x) will not introduce breaking changes. Semantic versioning makes developing dependent plugins much easier, because it ensures compatibility with a clearly stated number. It means updating the plugin within the same major release won't break your setup.
+
+AdvancedBan does not follow semver. On the contrary, it has made breaking changes within minor versions. For example, 2.3.0 is not guaranteed to be compatible with 2.2.1. As another example, version 2.1.6 changed the format of notify permissions.
+
+The purpose of semantic versioning is to avoid confusion and dependency conflicts by clearly defining compatibility. AdvancedBan's refusal to follow it means code made with a previous version of AdvancedBan could break after a seemingly small update.
+
+References:
+  * https://www.spigotmc.org/resources/advancedban.8695/update?update=367825
+  * https://www.spigotmc.org/resources/advancedban.8695/update?update=321631
+
+### Price
+
+Both AdvancedBan and LibertyBans are distributed at no cost.
+
+In the past, there was an update of AdvancedBan where **the author charged users to upgrade their data**. The update changed the plugin's data format but AdvancedBan did not provide a free migrator for users on previous versions.<sup id="note9ret">[9](#note9)</sup>
+
+### User Philosophy
+
+There is an increased tendency to cater to users' every wish in AdvancedBan. In LibertyBans, there is more of an emphasis on *doing things correctly* than making things easy. Cutting corners often leads to problems.
+
+An example of this difference in philosophy is a bug in AdvancedBan which causes it to take over other plugins' commands. For example, if you are running Essentials, `/essentials:ban` may actually become an AdvancedBan command! This is confusing behavior. It leads to silly error messages such as:
+
+> Unhandled exception during tab completion for command '/tempban Siikeee ' in plugin Essentials v2.18.1.0
+
+Even though it is AdvancedBan which is managing the /tempban command.<sup id="note10ret">[10](#note10)</sup> See also [the full error](https://pastebin.com/v46X9J2M).
+
+LibertyBans believes in better stewardship and will not take over other plugins' commands. If there is a conflicting command, users should solve the conflict through the correct means (using the server's commands.yml, defining aliases, etc.).
+
+## Requirements
+
+In general, LibertyBans uses more modern technology, but also has greater requirements.
+
+### Java Version Support
+
+LibertyBans requires Java 17 whereas AdvancedBan permits Java 8.
+
+### External Databases
+
+Using an external database in either plugin is optional. Both AdvancedBan and LibertyBans use HSQLDB by default.
+
+LibertyBans requires certain minimum versions for database servers. At least MySQL 8.0, MariaDB 10.6, or PostgreSQL 12 is required. Older versions are not supported.
+
+### Platform Support
+
+LibertyBans supports Sponge and Velocity, which AdvancedBan does not. Both support Bukkit and BungeeCord.
+
+Note that AdvancedBan has "unstable" Velocity support, but the feature has known bugs. Contributors say it is not maintained.<sup id="note11ret">[11](#note11)</sup>
+
+## Features
+
+AdvancedBan and LibertyBans each have several features the other does not.
+
+### Core punishment types
+
+* Both LibertyBans and AdvancedBan include bans, ip-bans, mutes, warns, and kicks.
+* AdvancedBan supports player notes, whereas LibertyBans does not.
+* By the nature of its flexible design, LibertyBans also supports ip-mutes, ip-warns, and ip-kicks, even though these are rarely used. It costs nothing to add these extra features.
+
+### Combatting Punishment Evasion (Alt Accounts)
+
+LibertyBans supports multiple modes of IP address-based punishment, in order to automatically block alt accounts. There is also a command to check for alts, as well as an automatic notification when an alt of a banned player joins the server.
+
+AdvancedBan has no similar functionality. It does have a command to check a player's IP address, however.
+
+### Exemption
+
+Although both plugins support the exemption feature which prevents staff from banning each other, it is implemented slightly differently.
+
+For offline players, AdvancedBan's permission checking depends on LuckPerms on proxies and Vault permissions on single servers. If these conditions are not met, the feature breaks silently for offline players.
+
+LibertyBans' exemption feature will never break silently. However, this imposes greater requirements. LibertyBans requires the installation of a supported exemption provider - currently LuckPerms or Vault. Without an exemption provider, the feature is entirely unavailable.
+
+### Importing From Other Plugins
+
+LibertyBans supports importing from AdvancedBan, BanManager, LiteBans, and vanilla.
+
+AdvancedBan does not provide any importers.
+
+### Converting Storage Backends
+
+LibertyBans allows the user to swap between storage backends using the self-import feature.
+
+AdvancedBan does not provide this feature itself, but [an extension plugin](https://github.com/A248/AdvancedBanMigrator) implements this conversion.
+
+### Punishment Listing
+
+AdvancedBan has /banlist, which is really a punishment list which includes all active punishments.
+
+LibertyBans' /banlist only shows bans, while /mutelist only shows mutes.
+
+Both plugins provide /history and /warns in the same manner.
+
+LibertyBans also includes /blame, which AdvancedBan does not.
+
+### Multi-Proxy / Multi-Instance Synchronization
+
+LibertyBans synchronizes punishments across multiple instances, if enabled. This is commonly used for multi-proxy setups.
+
+### Layouts
+
+AdvancedBan has a feature called layouts which specifies pre-defined reasons for use by staff.
+
+## References
+
+<a id="note1">1</a>: A248. "Singleton initialization beginning to show its weakness." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/406 [↩](#note1ret)
+
+<a id="note2">2</a>: A248. Discord message in Leoko.dev Discord guild. https://discord.com/channels/339110599084736522/380068075610963968/923016591585726554 [↩](#note2ret)
+
+<a id="note3">3</a>: jeeukko. "Store UUID of punisher in the database." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/435 [↩](#note3ret)
+
+<a id="note4">4</a>: A248. "Race condition between adding new bans and checking if the user is already banned." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/541 [↩](#note4ret)
+
+<a id="note5">5</a>: A248. "Database Queries on the Main Thread." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/458 [↩](#note5ret)
+
+<a id="note6">6</a>: AerWyn81. "ConcurrentModificationException on tempban command executed by another plugin." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/462 [↩](#note6ret)
+
+<a id="note7">7</a>: Leoko. Discord message in Leoko.dev Discord guild. https://discord.com/channels/339110599084736522/339110599084736522/745057107769819267 [↩](#note7ret)
+
+<a id="note8">8</a>: A248. "Database queries need not block each other." AdvancedBan Pull Request. https://github.com/DevLeoko/AdvancedBan/pull/393 [↩](#note8ret)
+
+<a id="note9">9</a>: Leoko. "AdvancedBan [1.7-1.12] v2.1.0 | Performance update." SpigotMC Resource Update. https://www.spigotmc.org/resources/advancedban.8695/update?update=180773 [↩](#note9ret)
+
+<a id="note10">10</a>: A248. "Friendly Register Commands Config Option. AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/pull/373 [↩](#note10ret)
+
+<a id="note11">11</a>: Hopefuls. Comment on "Create AdvancedBan on velocity." AdvancedBan Github Issue. https://github.com/DevLeoko/AdvancedBan/issues/547#issuecomment-1013552009 [↩](#note11ret)
+
+### Disclaimer
+
+Please note that no harm is meant to subjects of criticism. If the writing sounds harsh, we apologize; please let us know and we will make the language less harsh.

--- a/docs/zh-cn/Comparison-to-BanManager.md
+++ b/docs/zh-cn/Comparison-to-BanManager.md
@@ -1,0 +1,163 @@
+
+This is intended to be an impartial analysis of the API, design, and implementation of BanManager compared to LibertyBans.
+
+BanManager is somewhat unlike the other punishment plugins compared here (AdvancedBan, LibertyBans, LiteBans). It introduces several unique features and creative approaches. This is despite BanManager's much older codebase. As such, BanManager deserves additional credit.
+
+## Design
+
+### Database Schema
+
+The database schemas used by BanManager and LibertyBans are quite similar to each other.
+* Both plugins store the raw bytes of UUIDs and IP addresses, rather than using text: BINARY for UUIDs, VARBINARY for IP addresses.
+* Both store joining players' UUIDs and IP addresses, so that this information can be retrieved later as needed.
+* Both provide seconds-level precision for dates.
+
+Differences: 
+* BanManager additionally stores the undoing operator, the staff member who revoked a punishment. This enables staff to see who is responsible for unbans, unmutes, etc. Moreover, BanManager stores *when* the punishment was revoked.
+* BanManager stores whether a punishment was made silently.
+* Whereas BanManager repeats its schema, LibertyBans' schema is *normalized*, following common practice for relational database schemas.
+* LibertyBans uses fewer tables than BanManager to store the same amount of punishments, which may or may not improve code quality.
+
+### API
+
+The BanManager API requires callers to use static access. This decreases the quality of API users' code. Static access creates testing difficulties and makes it harder to reason about initialization order. This in turn will mean developers need to spend more time debugging their use of the BanManager API, which is frustrating and time-consuming for developers.
+
+Moreover, BanManager does not clearly delineate between the API and the implementation. It exposes its API in the same artifact as its common implementation. There is not a clear package separation: Methods in the API package accept classes outside the API package. This can easily lead to plugin developers depending on the internals of BanManager thinking those internals to be part of the API. In turn this would lead to breakage when the internals of BanManager are updated.
+
+Thirdly, BanManager exposes implementation details - such as its use of the ORMLite library - in its API. Coupling the API to a specific implementation library means that if BanManager wants to ever stop using such a library, it will need to break the API, or endure painful work-arounds to preserve compatibility.
+
+In contrast, the LibertyBans API is "object-oriented" following recommended Java practice. The API is clearly defined and completely separate from the implementation.
+
+## Implementation
+
+### Thread-Safety
+
+BanManager has known thread-safety problems.<sup id="note1ret">[1](#note1)</sup> I have not conducted a full analysis of the entire codebase, but it is possible there are other thread-safety bugs than the one cited.
+
+### API Documentation
+
+BanManager exposes API methods which perform database queries without clearly documenting that such methods may block the thread. This may lead to accidental queries on the main thread.
+
+In LibertyBans, all methods which might require an expensive computation return futures, which clearly informs callers of their heavyweight nature.
+
+### Code Quality
+
+Exception handling is an important factor in code quality. Lax exception handling weakens the strength of automated testing, since tests will not fail unless exceptions are correctly thrown. Exceptions help identify bugs quickly and effectively. When exceptions are hidden, developers must spend more time debugging issues, and users must spend more time figuring out why or whether a feature does not work.
+* BanManager frequently catches and logs exceptions. A search of the codebase for "printStackTrace()" yielded 291 matches.<sup id="note2ret">[2](#note2)</sup> Also, BanManager sometimes ignores exceptions entirely.
+* By contrast, LibertyBans had zero uses of Throwable#printStackTrace - not even in test code. LibertyBans will almost always re-throw exceptions rather than catch them. Valid exceptions are never intentionally ignored.
+* Additionally, BanManager sometimes catches NullPointerException, which is considered widely to be a bad practice.
+
+BanManager relies on Lombok for generating methods and constructors. Lombok is a hotly-debated library which uses annotations to automatically add Java code. Although some developers praise lombok because it reduces verbosity, this analysis will consider Lombok a mark of bad code quality. 
+* Lombok adds opacity and magic to a Java codebase. Lombok's features require a level of understanding similar to learning new language features.
+* Because Lombok relies on JDK internals, it frequently breaks when new Java versions are released. Although this breakage is strictly at compile-time and does not affect the operation of a compiled BanManager jar, it makes contributing to BanManager more difficult because contributors may need to switch JDKs.
+
+### Test Suite
+
+Both plugins run automated tests against their supported databases.
+
+However, BanManager's tendency to catch and log exceptions weakens its tests' effectiveness. Also, BanManager's tests appear to be less extensive than LibertyBans.<sup id="note3ret">[3](#note3)</sup>
+
+## Philosophy
+
+Overall, BanManager and LibertyBans are very similar in terms of development philosophy. Both plugins are distributed at no cost and are open-source.
+
+BanManager and LibertyBans may possibly differ with respect to the process for tackling bugs and implementing new features. Whether to fix bugs before implementing new features, whether to polish existing features before introducing new ones, and how much time should be spent considering the design of new features. However, these are quite subjective metrics.
+
+### Licensing
+
+BanManager's license prohibits commercial use. It is **illegal** to use BanManager for the purpose of monetary profit.<sup id="note4ret">[4](#note4)</sup>
+
+BanManager's license is the Creative Commons Non-Commercial - Share-Alike 2.0 (CC-BY-NC 2.0). In contrast, LibertyBans is licensed under the GNU Affero General Public License, v3 or later (GNU AGPL v3).
+
+Disclaimer: This is not legal advice and the writer is not a lawyer.
+
+## Requirements
+
+### Java Version Support
+
+LibertyBans requires Java 17 whereas BanManager permits Java 8.
+
+### External Databases
+
+Using an external database in either plugin is optional. BanManager uses H2 by default while LibertyBans uses HSQLDB by default.
+
+LibertyBans requires certain minimum versions for database servers. At least MySQL 8.0, MariaDB 10.6, or PostgreSQL 12 is required. Older versions are not supported.
+
+### Platform Support
+
+Both BanManager and LibertyBans support Bukkit and BungeeCord, and different versions of Sponge. Their differences:
+
+* LibertyBans supports Velocity.
+* LibertyBans supports Sponge 8, BanManager Sponge 7.
+  * The Sponge platforms are *not* compatible with each other. A plugin for Sponge 7 cannot operate on Sponge 8, and vice-versa.
+
+(As of 20 January 2022)
+
+## Features
+
+BanManager has a plethora of features: a wide array of commands and punishment types. The volume of features in BanManager is much more than in LibertyBans.
+
+LibertyBans avoids features it deems unnecessary. However, it has some features which BanManager does not.
+
+### Geyser Support
+
+LibertyBans has full support for Geyser.
+
+BanManager has partial support for Geyser - it assumes the Geyser name prefix is "*" and does not allow configuring this prefix.<sup id="note5ret">[5](#note5)</sup>
+
+### Core punishment types
+
+Both BanManager and LibertyBans include bans, ip-bans, mutes, ip-mutes, and kicks.
+
+LibertyBans provides warnings in a similar manner to other punishments. BanManager's warning feature is a different kind of punishment; warnings cannot be temporary under BanManager, but have "points" which can accumulate.
+
+The following punishment types are exclusive to the plugin listed:
+  * BanManager - Notes
+  * BanManager - Reports
+  * BanManager - Name bans
+  * BanManager - Bans of an IP address range
+  * LibertyBans - IP-warns and IP-kicks.
+
+LibertyBans supports ip-warns and ip-kicks by nature of its flexible design; it costs nothing to add these extra features.
+
+### Exemption
+
+LibertyBans offers the exemption feature which prevents staff from banning each other. It requires the installation of a backend exemption provider - LuckPerms or Vault - for this feature to operate.
+
+BanManager supports exemption, but players exempted from punishment must be written out in a YML file. The BanManager documentation states "This is required as Bukkit's permission system does not support offline players."<sup id="note6ret">[6](#note6)</sup> This is true, and it is why LibertyBans must depend on third-party permission APIs rather than Bukkit.
+
+### Importing From Other Plugins
+
+BanManager can import from AdvancedBan and vanilla.
+
+LibertyBans is able to import from AdvancedBan, BanManager, LiteBans, and vanilla.
+
+### Converting Storage Backends
+
+BanManager supports converting from H2 to MySQL or MariaDB, but not vice-versa. It is not possible to switch back to H2.<sup id="note7ret">[7](#note7)</sup>
+
+LibertyBans allows the user to swap between any supported storage backend using the self-import feature.
+
+### Additional BanManager features
+
+BanManager has further features which are not described in detail here, such as warning points and various utility commands.
+
+## References
+
+<a id="note1">1</a>: A248. "Race condition in BungeeCord implementation." BanManager Github Issue. https://github.com/BanManagement/BanManager/issues/956 [↩](#note1ret)
+
+<a id="note2">2</a>: A248. Used "rg --stats printStackTrace" on the BanManager source repository @ acb1ef1ebecefb7cfc8b4c255d635ccdb8b57482 and LibertyBans source repository @ f9490d1c8c7c4c59d40df163b8f77faa245efd15. 17 January 2022. [↩](#note2ret)
+
+<a id="note3">3</a>: A248. Analysis of BanManager source repository @ acb1ef1ebecefb7cfc8b4c255d635ccdb8b57482 and LibertyBans source repository @ f9490d1c8c7c4c59d40df163b8f77faa245efd15. 17 January 2022. [↩](#note3ret)
+
+<a id="note4">4</a>: "Creative Commons Legal Code: Attribution-NonCommercial 2.0." *Creative Commons*. Creative Commons. https://creativecommons.org/licenses/by-nc/2.0/legalcode [↩](#note4ret)
+
+<a id="note5">5</a>: BanManager source repository @ acb1ef1ebecefb7cfc8b4c255d635ccdb8b57482. https://github.com/BanManagement/BanManager/blob/acb1ef1ebecefb7cfc8b4c255d635ccdb8b57482/common/src/main/java/me/confuser/banmanager/common/util/StringUtils.java#L130 [↩](#note5ret)
+
+<a id="note6">6</a>: "exemptions.yml." _BanManagement_. https://banmanagement.com/docs/banmanager/configuration/exemptions-yml [↩](#note6ret)
+
+<a id="note7">7</a>: "Migrating from BanManager H2." _BanManagement_. https://banmanagement.com/docs/banmanager/migrations/h2 [↩](#note7ret)
+
+### Disclaimer
+
+Please note that no harm is meant to subjects of criticism. If the writing sounds harsh, we apologize; please let us know and we will make the language less harsh.

--- a/docs/zh-cn/Comparison-to-LiteBans.md
+++ b/docs/zh-cn/Comparison-to-LiteBans.md
@@ -1,0 +1,163 @@
+
+Since LiteBans is closed-source and pay-walled, it is hard to gather information about its workings. Very little is known about its internal code design. In fact, it may even be illegal to reverse-engineer LiteBans.
+
+This comparison will focus on what information is known about LiteBans.
+
+## Design
+
+### API
+
+LiteBans's API encourages users to query its database directly. As a  result, developers working with the LiteBans API have criticized it as a poor abstraction. Requiring API users to execute SQL tightly couples the database schema and API users.
+
+This has consequences:
+* If a plugin leaks a connection, it will appear that LiteBans is the source of the leak. Debugging connection leaks is further complicated because the LiteBans binary is obfuscated.
+* Creating a rigid database schema upon which API users rely means LiteBans is unable to improve its database schema without widespread breakage.
+
+LibertyBans instead provides an expansive Java API which attempts to cover the capabilities offered by a punishment plugin. In contrast to LiteBans, plugins using the LibertyBans API need not execute SQL.
+
+### Database Schema
+
+LiteBans, like other ban plugins, uses VARCHAR columns for storing UUIDs and IP addresses. This is equivalent to storing the string representation of UUIDs and IP addresses.
+
+LibertyBans uses BINARY column types in order to reduce storage space. This means only the necessary bytes of the UUIDs and IP addresses are stored. The actual difference is small, but not negligible.
+
+### Undoing Operator
+
+LiteBans stores the operator who revoked a punishment. This makes it possible for staff to determine who is responsible for unbans, unmutes, etc.
+
+LibertyBans does not store this information.
+
+## Implementation
+
+### Test Suite
+
+LibertyBans has an extensive test suite. Automated tests help catch bugs before a release can be made. The scope and strength of automated testing in LibertyBans has saved countless hours of development time.
+
+LiteBans is closed-source; as such, it is not clear whether it has a test suite. However, evidence suggests LiteBans has little automated testing:
+* LiteBans has experienced bugs which are of such a kind as to imply LiteBans does not have significant automated testing:
+  * "Fixed the /unwarn command, broken since 2.1" and "Fixed a harmless error when starting the plugin for the first time if config.yml doesn't exist yet" - https://www.spigotmc.org/resources/litebans.3715/update?update=102167
+  * "Fixed Database.prepareStatement() returning a closed statement" - https://www.spigotmc.org/resources/litebans.3715/update?update=163048
+  * A bug due to an invalid query string: https://gitlab.com/ruany/LiteBans/-/issues/391
+  * These kinds of bugs would most likely be prevented by automated testing
+* Bug descriptions frequently mention manual testing, but none of them mention automated testing.
+
+### Platform Separation
+
+The LibertyBans codebase is separated based on the platform.
+
+Separating code for each platform prevents whole categories of bugs relating to accidental class initialization. Fewer bugs means less time spent debugging and more time available for improving the rest of the plugin.
+
+Although LiteBans is closed-source, evidence strongly suggests that its codebase is *not* separated for each platform.<sup id="note1ret">[1](#note1)</sup>
+
+## Philosophy
+
+### Price and Availability
+
+LibertyBans is free and open-source. Anyone can inspect the source code if they so desire. Anyone can work on it; anyone can contribute and add features or modify it for own use. Users can use the latest version of the source code without having to wait until the next official release.
+
+LiteBans is closed-source. Only the author has access to the source code; only the author can implement new features. The JAR is obfuscated so that it cannot be decompiled into readable source code.
+
+LiteBans is also behind a pay-wall, meaning that users have to pay in order to use it. This also means that prospective users cannot test out the plugin so easily. They have to pay before testing.
+
+Users of LiteBans must carefully consider whether they are willing to rely entirely on the author of LiteBans for features and improvements.
+
+### Support
+
+Support for LibertyBans is provided through GitHub Issues and a dedicated text channel on a Discord Server.
+
+LiteBans primarily offers support through Discord; however, it only does so for users who verified their purchase of the plugin. This also includes requesting support for their API, meaning if you're not a customer of their plugin, chances are low you will gain access to their support server, or receive help with their API at all.
+
+### Versioning
+
+LiteBans does not follow semantic versioning, leading to potential instability for developers using its API. It has introduced new API without issuing a minor release.<sup id="note2ret">[2](#note2)</sup>
+
+LibertyBans fully follows semantic versioning for its API.
+
+## Requirements
+
+### Java Version Support
+
+LibertyBans requires Java 17 whereas LiteBans permits Java 8.
+
+### External Databases
+
+Neither LibertyBans nor LiteBans requires an external database. LibertyBans uses HSQLDB by default, and LiteBans uses H2 by default.
+
+Both LibertyBans and LiteBans support MariaDB, MySQL, and PostgreSQL. LiteBans also has support for SQLite, but SQLite usage is discouraged by LiteBans.
+
+LibertyBans requires certain minimum versions for database servers. At least MySQL 8.0, MariaDB 10.3, or PostgreSQL 12 is required. Older versions are not supported.
+
+## Platform Support
+
+* Bukkit, BungeeCord, and Velocity are supported by both plugins.
+* Sponge:
+  * LibertyBans supports Sponge.
+  * LiteBans declines to support Sponge on the author's reason that Sponge does not provide asynchronous chat events.<sup id="note3ret">[3](#note3)</sup>
+
+LiteBans' support for Velocity came after repeated user requests. It was suggested that LiteBans be made open-source so that someone could contribute a Velocity version. The reluctance of the LiteBans author to add Velocity support suggests that it may be unwise to rely on proprietary software for critical functionality.
+
+## Features
+
+### Geyser Support
+
+LibertyBans and LiteBans have Geyser support.
+
+However, documentation suggests LiteBans requires the prefix to be the period character (".").<sup id="note4ret">[4](#note4)</sup>
+
+### Core punishment types
+
+Both LibertyBans and LiteBans include bans, ip-bans, mutes, warns, and kicks.
+
+By the nature of its flexible design, LibertyBans also supports ip-mutes, ip-warns, and ip-kicks, even though these are rarely used. It costs nothing to add these extra features.
+
+LiteBans allows banning IP ranges. LibertyBans does not.
+
+### Combatting Punishment Evasion (Alt Accounts)
+
+Both LibertyBans and LiteBans have a command to check for alts as well as an automatic notification when an alt of a banned player joins the server.
+
+LibertyBans further supports multiple modes of IP address-based punishment, in order to automatically block alt accounts. LiteBans does not have this feature.
+
+### Exemption
+
+Although both plugins support the exemption feature which prevents staff from banning each other, it is implemented slightly differently.
+
+For offline players, LiteBans's permission checking depends on Vault on single servers. Without a Vault-compatible permissions plugin, the feature breaks silently for offline players.
+
+LibertyBans' exemption feature will never break silently. However, it requires the installation of a supported exemption provider - currently LuckPerms or Vault. Without an exemption provider, the feature is entirely unavailable.
+
+Moreover, LiteBans' exemption does not provide arbitrary levels.<sup id="note5ret">[5](#note5)</sup>
+
+### Importing From Other Plugins
+
+LibertyBans supports importing from AdvancedBan, BanManager, LiteBans, and vanilla.
+
+LiteBans supports importing from AdvancedBan, BanManager, BungeeAdminTools, MaxBans, UltraBans, and vanilla.
+
+### Server Scopes
+
+Both plugins enable punishments scoped to certain servers.
+
+However, LiteBans lacks scope categories, or the ability to group servers into a single scope.<sup id="note6ret">[6](#note6)</sup>
+
+### Multi-Proxy / Multi-Instance Synchronization
+
+Both LibertyBans and LiteBans provide synchronization across multiple instances, a feature commonly used for multi-proxy setups.
+
+## References
+
+<a id="note1">1</a>: Falistos. "Start error under Java 18." LiteBans Gitlab Issue. https://gitlab.com/ruany/LiteBans/-/issues/408 [↩](#note1ret)
+
+<a id="note2">2</a>: Ruan. "LiteBans 2.5.4 - 2.5.9." SpigotMC Resource Update. https://www.spigotmc.org/resources/litebans.3715/update?update=341296 [↩](#note2ret)
+
+<a id="note3">3</a>: Ruan. "[Feature] Spongepowered?". LiteBans Gitlab Issue Comment. https://gitlab.com/ruany/LiteBans/-/issues/41#note_324182783 [↩](#note3ret)
+
+<a id="note4">4</a>: Ruan. "LiteBans 2.7.5 (Connection error fix)". SpigotMC Resource Update. https://www.spigotmc.org/resources/litebans.3715/update?update=414133 [↩](#note4ret)
+
+<a id="note5">5</a>: Ruan. "LiteBans Exempt". LiteBans Gitlab Issue Comment. https://gitlab.com/ruany/LiteBans/-/issues/223 [↩](#note5ret)
+
+<a id="note6">6</a>: lewisakura. "Server scope groups". LiteBans Gitlab Issue. https://gitlab.com/ruany/LiteBans/-/issues/452 [↩](#note6ret)
+
+### Disclaimer
+
+Please note that no harm is meant to subjects of criticism. If the writing sounds harsh, we apologize; please let us know and we will make the language less harsh.

--- a/docs/zh-cn/Configuration.md
+++ b/docs/zh-cn/Configuration.md
@@ -1,0 +1,30 @@
+
+配置文件大多数都不言自明。
+
+### 语法
+
+LibertyBans 的配置文件是您熟悉的“.yml ”文件。请使用 [在线 YAML 语法检查器](https://www.json.cn/yaml-editor/) 验证配置文件。
+
+译者注：原文的语法检查链接在这里: [Online Yaml Parser](https://yaml-online-parser.appspot.com)
+
+## 重载配置
+
+您可以通过以下命令重新加载大部分配置：
+
+```
+/libertybans reload
+```
+
+您必须拥有必要的 [权限](Permissions) 才能这么做.
+
+### 重启插件
+
+对于 sql.yml 中的设置与少部分设置，您需要完全重启服务器。
+
+```
+/libertybans restart
+```
+
+### 附加功能
+
+安装 [附加功能](Addons) 需要服务器完全重启。

--- a/docs/zh-cn/Database-Performance.md
+++ b/docs/zh-cn/Database-Performance.md
@@ -1,0 +1,52 @@
+
+LibertyBans' performance is strongly related to database query performance. Fast database access equates to fast plugin performance.
+
+This page is mostly useful for large servers looking to ensure efficient operation.
+
+### Performance Factors
+
+Performance largely depends on the database queries issued to check incoming players for bans and chatting players for mutes. Every time a player connects to the server, or sends a chat message, a database query is executed. If these queries take longer, connections and chat messages will become delayed.
+
+To reduce database queries issued for chat messages, LibertyBans uses a mute cache. This prevents players chatting frequently from overwhelming the database. The mute cache keeps track of players who recently chatted and whether they are muted.
+
+## Performance Configuration
+
+### Address Strictness
+
+The configured address strictness directly affects query performance. Scalability is the primary concern. If a query is scalable, its execution time will not depend on the quantity of data. For example, a scalable query should yield similar results on a database with 100 punishments as on a database with 100,000 punishments.
+
+Introducing the **Rule of Preservation of Scalability:** In LibertyBans' queries, *scalability* is usually preserved by choosing a stricter level.
+  * This point is crucial. It means that query performance is not dependent on the number of stored punishments.
+  * There is one exception to the Rule of Preservation of Scalability. Using the default HSQLDB database with `STERN` or `STRICT` eliminates scalability of enforcement queries, as investigated in [#190](https://github.com/A248/LibertyBans/issues/190). Large servers are therefore discouraged from using HSQLDB with either `STERN` or `STRICT` settings.
+
+Generally, progressively stricter address strictness options increase execution time. More computational work is necessary to fulfill a greater level of address strictness. However, thanks to the Rule of Preservation of Scalability, this slightly greater per-query execution cost is relatively non-consequential.
+
+### Connection Pool Size
+
+Following recommended technical practice, LibertyBans uses a fixed connection pool. By default, the connection pool is quite small with only 6 connections.
+
+You will likely be surprised to find that a pool of 6 connections can service a large server with many players connecting and chatting. For a large network with LibertyBans installed on the proxy, you may wish to increase the connection pool size.
+
+Please keep in mind that a larger connection pool does not necessarily mean better performance. Too often, administrators make pool sizes too large, which in fact reduces performance. Read [this page](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) to better understand connection pool sizing.
+
+### Mute Cache Settings
+
+Increasing the mute cache expiration time means mutes will be stored for longer, and therefore, fewer queries will be made to the database.
+
+The expiration semantic does affect performance, but it should be configured on the basis of correct behavior as priority.
+
+## Common Issues
+
+### Network Latency
+
+If your database is slow to respond, that will translate to LibertyBans taking longer to check bans and mutes.
+
+Ensure the database is not located in a geographically distant region (for example, a MySQL database in Antarctica).
+
+### Connection Pool Overload
+
+If you run a large network with LibertyBans installed on the proxy, the default connection pool size may be insufficient to meet your needs. If you repeatedly notice players taking too long to login or chat, try increasing the connection pool size.
+
+If you are familiar debugging, it is fairly easy to investigate connection pool load by using either live debugging tools or logging configuration to monitor connection pool events.
+
+Another solution to an overloaded connection pool is more aggressive mute caching.

--- a/docs/zh-cn/Developer-API.md
+++ b/docs/zh-cn/Developer-API.md
@@ -1,0 +1,214 @@
+## Dependency Information
+
+The dependency FQDN is:
+
+````
+space.arim.libertybans:bans-api:{VERSION}
+````
+
+It is available from:
+
+```
+https://mvn-repo.arim.space/affero-gpl3/
+```
+<!-- tabs:start -->
+
+#### **Maven**
+
+With maven, this would be applied as follows:
+
+```xml
+<dependencies>
+	<dependency>
+		<groupId>space.arim.libertybans</groupId>
+		<artifactId>bans-api</artifactId>
+		<version>{INSERT_LATEST_VERSION}</version>
+	</dependency>
+	...
+</dependencies>
+
+<repositories>
+	<repository>
+		<id>arim-mvn-agpl3</id>
+		<url>https://mvn-repo.arim.space/affero-gpl3/</url>
+	</repository>
+	...
+</repositories>
+```
+
+#### **Gradle**
+
+```gradle
+repositories {
+  ...
+    maven { 
+      name= 'arim-mvn-lgpl3' 
+      url = 'https://mvn-repo.arim.space/lesser-gpl3/' 
+    }
+    maven { 
+      name= 'arim-mvn-gpl3' 
+      url = 'https://mvn-repo.arim.space/gpl3/' 
+    }
+    maven { 
+      name= 'arim-mvn-agpl3' 
+      url = 'https://mvn-repo.arim.space/affero-gpl3/' 
+    }
+  ...
+}
+
+dependencies {
+  ...
+    compileOnly "space.arim.libertybans:bans-api:{INSERT_LATEST_VERSION}"
+}
+```
+
+<!-- tabs:end -->
+
+
+### Javadoc
+
+The javadocs are attached to the artifact and your IDE should be able to download them.
+
+## API Usage
+
+### Getting the instance
+
+The first step to use the API is to get the instance of LibertyBans installed. This should be done once, such as when your plugin starts. Then, when access to the API is required, the instance you previously acquired should be passed.
+
+```java
+public class WikiExamples {
+
+	private final Omnibus omnibus;
+	private final LibertyBans libertyBans;
+
+	public WikiExamples(Omnibus omnibus, LibertyBans libertyBans) {
+		this.omnibus = omnibus;
+		this.libertyBans = libertyBans;
+	}
+	
+	public static WikiExamples create() {
+		Omnibus omnibus = OmnibusProvider.getOmnibus();
+		LibertyBans libertyBans = omnibus.getRegistry().getProvider(LibertyBans.class).orElseThrow();
+		return new WikiExamples(omnibus, libertyBans);
+	}
+	
+}
+```
+
+### Adding Punishments
+
+Creating punishments starts with a `DraftPunishment`, which is obtained from `PunishmentDrafter`. The draft punishment is sent to LibertyBans, which will add the punishment to the database and return a full `Punishment`.
+
+Building on the previous example, here's what that might look like.
+
+```java
+public void banPlayerUsingLibertyBans(UUID uuidToBan) {
+
+	PunishmentDrafter drafter = libertyBans.getDrafter();
+
+	DraftPunishment draftBan = drafter
+		.draftBuilder()
+		.type(PunishmentType.BAN)
+		.victim(PlayerVictim.of(uuidToBan))
+		.reason("Because I said so")
+		.build();
+
+	draftBan.enactPunishment().thenAcceptSync((punishment) -> {
+		// In this example it is assumed you have a logger
+		// You should not copy and paste examples verbatim
+		if (punishment == null) {
+			logger.info("UUID {} is already banned", uuidToBan);
+			return;
+		}
+		logger.info("ID of the enacted punishment is {}", punishment.getIdentifier());
+	});
+}
+```
+
+### Getting Punishments
+
+There is a comprehensive punishment selection API which allows you to retrieve punishments with certain details. For example, to get all mutes issued by a specific staff member:
+
+```java
+public ReactionStage<List<Punishment>> getMutesFrom(UUID staffMemberUuid) {
+	return libertyBans.getSelector()
+		.selectionBuilder()
+		.type(PunishmentType.MUTE)
+		.operator(PlayerOperator.of(staffMemberUuid))
+		.build()
+		.getAllSpecificPunishments();
+}
+```
+
+If you want to determine whether a player is muted, you should select *applicable* punishments (i.e., which includes user and IP mutes):
+
+```java
+public ReactionStage<Optional<Punishment>> getMutesApplyingTo(UUID playerUuid, InetAddress playerAddress) {
+	return libertyBans.getSelector()
+		.selectionByApplicabilityBuilder(playerUuid, playerAddress)
+		.type(PunishmentType.MUTE)
+		.build()
+		.getFirstSpecificPunishment();
+}
+```
+
+### Removing Punishments
+
+Assuming you already have a `Punishment` instance, `Punishment#undoPunishment` will remove the punishment easily.
+
+If you don't have a punishment instance on hand, you can use the `PunishmentRevoker`:
+
+```java
+public ReactionStage<?> revokeBanFor(UUID bannedPlayer) {
+	PunishmentRevoker revoker = libertyBans.getRevoker();
+
+	// Relies on the fact a single victim can only have 1 active ban
+        RevocationOrder revocationOrder = revoker.revokeByTypeAndVictim(
+		PunishmentType.BAN, PlayerVictim.of(bannedPlayer)
+        );
+	return revocationOrder.undoPunishment().thenAccept((undone) -> {
+		if (undone) {
+			// ban existed and was undone
+		} else {
+			// there was no ban
+		}
+	});
+}
+```
+
+### Listening to Events
+
+Suppose you want to run code when a player is punished. Here's how you'd do that using `PunishEvent`:
+
+```java
+public void listenToPunishEvent() {
+	EventConsumer<PunishEvent> listener = new EventConsumer<>() {
+		@Override
+        public void accept(PunishEvent event) {
+			logger.info("Listening to punish event {}", event);
+		}
+	};
+	omnibus.getEventBus().registerListener(PunishEvent.class, ListenerPriorities.NORMAL, listener);
+}
+```
+
+The full list of events is in the javadoc.
+
+### ReactionStage
+
+As you may have noticed, ReactionStage is a subinterface of CompletionStage. It can be converted to a CentralisedFuture, which is a subclass of CompletableFuture, via `toCompletableFuture`. **If you have not used CompletableFuture or CompletionStage before, you will need to understand those classes first.**
+
+ReactionStage/CentralisedFuture is analogous to CompletionStage/CompletableFuture. They're almost exactly the same - ReactionStage/CentralisedFuture extend CompletionStage/CompletableFuture and add a couple more methods.
+
+You can use CompletionStage/CompletableFuture to decouple your plugin from LibertyBans, but you may also want to take advantage of the *Sync* methods on CentralisedFuture.
+
+The sync methods allow you to run callbacks and operations on the main thread similarly how to the *Async* methods run on the common ForkJoinPool. Additionally, CentralisedFuture#join is enhanced to prevent deadlocks should you use `join()`, `get()`, or `get(long, TimeUnit)` while on the main thread. This means that if you have an intermediate operation which depends on the main thread, you can await its completion even if on the main thread itself:
+
+```java
+CentralisedFuture<?> future;
+future.thenRunSync(() -> { // thenRunSync is not available with CompletableFuture
+ // do operation on main thread
+}).thenRunAsync(() -> {
+ // do async operation
+}).join(); // Calling join() will cause a deadlock when using a plain CompletableFuture
+```

--- a/docs/zh-cn/Getting-Started.md
+++ b/docs/zh-cn/Getting-Started.md
@@ -1,0 +1,55 @@
+### 惩罚类型
+
+有四种类型:
+封禁(ban)、禁言、踢出和警告.
+
+每种惩罚可以是一个玩家或其 IP 地址。取决于配置文件中的 address-strictness(地址严格性) 选项。
+
+### 命令
+
+一个基本的格式例如 /ban, /mute 和 warn 他们的用法都是 `/<命令> <对象> [时间] <原因>`
+
+禁言/禁制/警告玩家时，如果没有指定时间参数，玩家将被永久禁言。
+例如:
+* `/ban FakeOwner Obedience is liberating` -> FakeOwner 将会以 “Obedience is liberating” 的理由被永久封禁
+* `/ban FakeOwner permanently Obedience is liberating` -> FakeOwner 将会以 “Obedience is liberating” 的理由被永久封禁
+* `/ban FakeOwner 5d Obedience is liberating` -> FakeOwner 将会以 “Obedience is liberating” 的理由被**封禁5天**
+> Obedience is liberating 指 服从是一种解放
+
+### 时间格式
+时间格式参照这个简单的公式：
+`<数字><时间单位>`
+
+可用的时间公式:
+* m = 分钟
+* h = 小时
+* d = 天
+* mo = 月
+
+例如:
+* 3h -> 3 小时
+* 8d -> 8 天
+* 1mo -> 1 月
+* 1m -> 1 分钟
+
+### 对象
+
+可以使用玩家的姓名或 IP 地址封禁玩家。
+
+* 如果您指定了一个名字，LibertyBans 会根据 UUID 进行封禁，即使玩家更改名称也无法逃离 LibertyBans 的手掌心。
+* 如果您指定一个 IP 地址，LibertyBans 将按 IP 地址进行封禁，也就是封禁该 IP 地址的所有玩家。(另请参阅 [惩罚类型](Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings)).
+
+封禁实例:
+
+* `/ban DeviousPlayer` - 封禁 DeviousPlayer。
+* `/ban 192.110.162.103` - 封禁 IP 地址 192.110.162.103。
+* `/ipban 192.110.162.103` - 封禁 IP 地址 192.110.162.103。 相当于 `/ban 192.110.162.103`
+* `/ipban DeviousPlayer` - 封禁 DeviousPlayer 的 IP 地址。
+
+解封示例:
+
+* `/unban SaintlyPlayer` - 解除封禁 SaintlyPlayer.
+* `/unban 192.222.222.222` - 解除封禁 IP 地址 192.110.162.103。
+* `/unbanip 192.222.222.222` - 解除封禁 IP 地址 192.110.162.103。 相当于 `/ban 192.110.162.103`
+* `/unbanip SaintlyPlayer` - 解除封禁 DeviousPlayer 的 IP 地址。
+

--- a/docs/zh-cn/Guide-to-Composite-Punishments.md
+++ b/docs/zh-cn/Guide-to-Composite-Punishments.md
@@ -1,0 +1,62 @@
+
+A composite punishment is one which applies to a UUID and an IP address. Composite punishments are an advanced topic, and you should be sure to understand how they work before you employ them.
+
+### Terminology
+
+This page will use the term "composite ban" for simplicity and convenience. However, it is also possible to create composite punishments which are mutes, warns, and kicks, in the same manner.
+
+You should be familiar with UUIDs and IP addresses, the relation of these to users, and when these change.
+
+## Definition
+
+* A user ban applies to a UUID.
+* An IP ban applies to an IP address.
+* A composite ban applies to a UUID and an IP address.
+
+### Features
+
+With respect to enforcing punishments, a composite ban is much akin to an IP-ban.
+* Using LENIENT strictness, any user with the banned UUID or the banned address will be banned.
+  * Composite bans are thus useful if you desire punishment stricter than a LENIENT IP ban, which bans only players with the address, but not as restricting as a NORMAL IP ban, which bans all players that have ever had that address.
+* Using NORMAL, STERN, or STRICT strictness, the applicable users are the same as if the ban was an IP ban.
+  * This is because, under STERN/NORMAL/STRICT strictness, an IP ban will always apply to the user who had that IP address, so it will be as if the user's UUID was banned too.
+  * Recall the explanations of [punishment enforcement](Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings)
+
+With respect to creating, undoing, and listing punishments with commands, composite bans are arguably easier to use than IP bans.
+  * In punishment messages, composite victims are displayed as a username rather than an IP address.
+  * If you use the `composite-by-default` config option:
+    * `/ban Player1` creates a composite ban.
+    * `/unban Player1` undoes a composite ban.
+  * Because a composite ban applies to a user, it will show up in /history, /warns, and other listing commands for that user. 
+
+### Caveats
+
+Normally, it is impossible to create a ban or mute applying to an existing banned or muted UUID or IP address. If you ban Player1, then attempt to re-ban Player1, LibertyBans will tell you this player is already banned.
+
+* However, one *can* create different composite bans applying to the same UUID but different IP addresses.
+* One can also create different composite bans applying to different UUIDs but the same IP address.
+
+To clarify matters:
+* You cannot create multiple bans or mutes applying to the exact same victim. A victim is a punishment subject such as:
+  * A UUID, in the case of a UUID punishment
+  * An IP address, in the case of an IP punishment
+  * A UUID and IP address combination, in the case of a composite punishment
+* Two separate composite punishments, applying to the same UUID but different IP addresses, have *different victims*, therefore it is possible for them to co-exist as active punishments.
+
+### Enacting and Revoking Punishments
+
+Most of the time, the composite victim functionality should simply function in a manner which is intuitive and friendly. However, this friendly top-level interface is achieved by somewhat complex mechanisms. It is best to document these here.
+
+Enacting a punishment is simple. The target user's UUID and address combination is punished.
+
+Revoking a punishment tries to be as helpful as possible in determining which punishment needs to be revoked.
+* The first punishment which matches the specified criteria is revoked:
+  * If you unban a username, the plugin attempts to unban the UUID. If that fails, the plugin attempts to undo any composite ban whose UUID is the specified user's UUID, disregarding the address of the undone composite ban.
+  * If you unban an IP address, the plugin attempts to unban the IP address. If that fails, the plugin attempts to undo any composite ban whose IP address is the specified IP address, disregarding the UUID of the undone composite ban.
+  * In other words, LibertyBans tries to find any punishment which you might mean when you type `/unban Player1' or `/unban 127.0.0.1` - either a simple victim or a composite victim.
+  * Note that this process is performed in a single database query.
+* This functionality happens regardless of whether you use the composite-by-default feature.
+
+## Conclusion
+
+Please be sure that you understand composite punishments before you employ them.

--- a/docs/zh-cn/Importing-from-Other-Plugins.md
+++ b/docs/zh-cn/Importing-from-Other-Plugins.md
@@ -1,0 +1,64 @@
+LibertyBans supports importing from the following sources:
+
+* AdvancedBan
+* BanManager
+* LiteBans
+* Vanilla server bans (includes Essentials)
+  * Importing vanilla bans requires that you run LibertyBans on Bukkit during the import process. Once the import is complete you can move LibertyBans to any supported platform.
+* LibertyBans itself, for the purpose of switching storage backends. See [self-importing](Self-Importing) for more information.
+
+If you do not see your plugin listed here, open a [new issue](https://github.com/A248/LibertyBans/issues) and describe the feature request.
+
+# Importing Steps
+
+1. Backup your data. Taking backups is good practice, *always*. If you want to be extra safe, be sure that you can restore your backup, too.
+2. Configure the `import.yml`.
+3. Run the import command - `/libertybans import <source>`.
+
+# Caveats
+
+Importing is not a 1-to-1 process, because storage methods vary across plugins.
+
+## UUID Support in AdvancedBan and vanilla
+
+| Import source | UUID Support - Victims | UUID Support - Operators |
+|---------------|------------------------|--------------------------|
+| AdvancedBan   | ✔️                     | ❌                        |
+| BanManager    | ✔️                     | ✔️                       |
+| LiteBans      | ✔️                     | ✔️                       |
+| Vanilla       | ❌                      | ❌                        |
+
+
+
+AdvancedBan and vanilla bans use names in some places where LibertyBans needs UUIDs. LibertyBans uses UUIDs everywhere, so a UUID lookup will be performed in these cases.
+
+How UUID lookups are performed is controlled by the uuid-resolution and server-type settings in the `config.yml`. 
+
+* If you are running a normal online-mode server, you will want to add additional web API resolvers. Without this, your server will be rate-limited by Mojang for performing too many UUID lookups:
+```
+player-uuid-resolution:
+  server-type: 'ONLINE'
+  web-api-resolvers:
+    - 'ASHCON' // Example - Add this first
+    - 'MOJANG' 
+```
+
+* If you are running an offline-mode (cracked) server, and using `CRACKED` UUIDs – i.e., all players have cracked UUIDs – then you don't need to do anything. LibertyBans will assume the user is cracked and calculate their cracked UUID.
+
+* If you are running an offline-mode server, and using `MIXED` UUIDs, where some players have cracked UUIDs and some have online UUIDs, LibertyBans cannot perform any UUID lookups. Some punishments *will be skipped* if LibertyBans cannot determine the UUID.
+  * You can avoid losing punishments if all the users join the server first, or have joined the server since LibertyBans was installed. If the players have joined the server before, LibertyBans will remember their name and UUID, and so when the import occurs, LibertyBans will know the UUID of these players.
+
+## LiteBans – Using  H2
+
+If you used LiteBans with MariaDB, MySQL, or PostgreSQL, no additional setup is required. LibertyBans includes these drivers.
+
+If you used LiteBans with H2, you will need to download and install the driver first:
+
+1. Download the H2 driver jar:
+  * [Direct download link](https://repo1.maven.org/maven2/com/h2database/h2/1.4.199/h2-1.4.199.jar)
+  * [Maven Central link](https://mvnrepository.com/artifact/com.h2database/h2/1.4.199)
+2. Find the `LibertyBans/internal/attachments` directory. Upload the driver jar here.
+3. Restart the server.
+4. Run the import process as you normally would.
+
+For help, join the discord for support.

--- a/docs/zh-cn/JSON-Messages.md
+++ b/docs/zh-cn/JSON-Messages.md
@@ -1,0 +1,40 @@
+JSON messages in LibertyBans are based on RezzedUp's [json.sk](https://www.spigotmc.org/resources/json-sk.8851/). If you have used Skript's JSON.sk or otherwise already use json.sk formatting, you don't need to read this guide. All messages can use json.sk formatting.
+
+### What is JSON in Minecraft? ###
+
+JSON is a way of sending complex messages to players. JSON lets you send hoverable text, clickable links, and much more, putting dynamism in your chat with user-friendly messages.
+
+You may be familiar with the `/tellraw` command. Using /tellraw, you can send JSON messages to other players. However, the format of tellraw is not the best. It looks like: `tellraw @a ["",{"text":"Basic","bold":true,"color":"yellow"},{"text":" tellraw example with ","color":"yellow"},{"text":"tooltip","color":"yellow","hoverEvent":{"action":"show_text","value":"Hey look at this"}},{"text":" and ","color":"yellow"},{"text":"command","color":"yellow","clickEvent":{"action":"run_command","value":"/kill"}}]`.
+
+### How do I use the JSON Format?
+
+The JSON format revolves around **clusters**. You can create a new cluster like so:
+`this is part 1.||part 2 - a new cluser!`
+
+Clusters aren't useful unless you add something to them. These are the available JSON tags:
+* `ttp:` - adds a *tooltip*. If a player moves their cursor over the tooltip, they will see the specified text.
+* `cmd:` - adds a command. If a player clicks the text, they will run the specified command.
+* `sgt:` - adds a suggestion. If a player clicks the text, the specified text will enter their chat input.
+* `url:` - adds a URL. If a player clicks the text, it will take them to the URL.
+
+Take a look at this:
+
+```
+"&7&oHello, this is a &bsample json&7.||ttp:&bI'm a tooltip for the first cluster.|| There's no tag, so I've started a new cluster.||cmd:/ping||ttp:&6&o&lCLICK&f for /ping")
+||___________________________________|  |________________________________________||||_____________________________________________|  |_______|  |_________________________||
+|            Average Text                                Tooltip                  ||                 Average Text                   Run Command           Tooltip          |
+|_________________________________________________________________________________||_______________________________________________________________________________________|
+                                  JSON Cluster #1                                                                           JSON Cluster #2
+```
+Results in:
+
+![Result_image1](https://i.imgur.com/xlnlX02.png)
+![Result_image2](https://i.imgur.com/FSAgQUJu.png)
+
+Note that JSON messages are only for chat. Putting them in kick messages, for example, will have no effect.
+
+### Escaping the JSON syntax
+
+To escape double pipes, double them (use quadruple pipes):
+
+`This is a double pipe: ||||` results in `This is a double pipe: ||`

--- a/docs/zh-cn/Misbehaving-Plugins.md
+++ b/docs/zh-cn/Misbehaving-Plugins.md
@@ -1,0 +1,38 @@
+Let's say you see this message in your server console:
+
+```
+10.05 14:41:56 [Server] ERROR [space.arim.libertybans.core.env.ParallelisedListener]: You likely have a misbehaving plugin installed on your server. 
+This may lead to bans or mutes not being checked and enforced.
+
+Reason: the event PlayerChatEvent<some information> was previously blocked by the server or another plugin, but since 
+then, some plugin has uncancelled the blocking.
+```
+
+This is a helpful message emitted by LibertyBans warning you that you likely have a misbehaving plugin.
+
+Other ban plugins do not issue the same warning - they don't report the problem, but it will occur silently.
+
+### Solving the Issue
+
+You have another plugin installed on your server which is probably misbehaving. I recommend investigating the situation by setting up a test server and seeing if you can get this message to go away by adding and removing plugins. If you remove plugin X and the message disappears, you know that plugin X is at fault.
+
+### Technical Explanation
+
+This means something very specific. It relates to how events are processed by different plugins. The way event systems work, first the event is passed to one plugin, then another, then the next:
+
+```
+1. Plugin A listens to the chat event
+2. LibertyBans listens to the chat event
+3. Plugin B listens to the chat event
+```
+
+Any of these plugins may *cancel* the event. If they do, the other plugins still see the event, but they see that it is cancelled. Plugins can also *undo* the cancellation of an event.
+
+Normally, if a player is muted, LibertyBans will cancel the chat event for that player.
+
+LibertyBans does its job to cancel the chat event if the event is not already cancelled. However, the following can occur:
+1. Plugin A cancels the chat event
+2. LibertyBans sees the cancelled event and ignores it as a result
+3. Plugin B *un-cancels* the chat event
+
+The console message is a warning that this situation has occurred. If this happens, you have a plugin like `Plugin B` which is un-cancelling chat events. Regardless of how LibertyBans is designed, a plugin un-cancelling chat events has the capability to allow muted players to talk. That plugin will have to be fixed.

--- a/docs/zh-cn/Permissions.md
+++ b/docs/zh-cn/Permissions.md
@@ -1,0 +1,99 @@
+
+推荐使用 LibertyBans 1.0.x 版本。如需查看关于 LibertyBans 0.8.x 的权限配置，请向下滚动。
+
+# LibertyBans 1.0
+
+### 任何命令 ###
+
+作为执行任何命令的前提条件，您必须拥有权限：
+
+`libertybans.commands`
+
+## 惩罚 ##
+
+### 封禁 ###
+
+* `libertybans.ban.do.target.uuid` - 封禁玩家
+* `libertybans.ban.do.target.ip` - 封禁 IP 地址
+* `libertybans.ban.do.target.both` - 在同一惩罚中封禁玩家和 IP 地址
+* `libertybans.ban.do.silent` - 使用悄悄封禁功能 (也就是 `ban -s`)
+* `libertybans.ban.do.notify` - 收到玩家被封禁的通知
+* `libertybans.ban.do.notifysilent` - 收到玩家被封禁的通知，即使是悄悄封禁
+* `libertybans.ban.undo.target.uuid` - 解封玩家
+* `libertybans.ban.undo.target.ip` - 解封 IP 地址
+* `libertybans.ban.undo.target.both` - 在同一惩罚中解封玩家和 IP 地址
+* `libertybans.ban.undo.silent` - 使用悄悄解封功能 (也就是 `unban -s`)
+* `libertybans.ban.undo.notify` - 收到玩家被解封的通知
+* `libertybans.ban.undo.notifysilent` -收到玩家被解封的通知，即使是悄悄解封
+
+* 如果启用了持续时间权限：* 需要使用 `libertybans.ban.dur.<timespan>` 来控制玩家封禁时长。
+  * 使用 _libertybans.ban.dur.perm_ 来获得永久期限。
+  * 时间跨度的格式与命令相同。libertybans.ban.dur.6d "允许禁言最多六天。
+  * 如果一个玩家有多个持续时间的权限节点，则使用最长的持续时间。
+
+### 禁言 ###
+
+和封禁的权限类似，只是权限以 `libertybans.mute` 开头.
+
+### 警告 ###
+
+和封禁的权限类似，只是权限以 `libertybans.warn` 开头.
+
+### 踢除 ###
+
+和封禁的权限类似，只是权限以 `libertybans.kick` 开头.
+
+由于显而易见的原因，踢除没有持续时间权限；此外，除也没有 “解禁”功能。
+
+## 列表
+
+* `libertybans.list.banlist` - /banlist
+* `libertybans.list.mutelist` - /mutelist
+* `libertybans.list.history` - /history
+* `libertybans.list.warns` - /warns
+* `libertybans.list.blame` - /blame
+
+## 小号管理
+
+* `libertybans.alts.command` - /alts 指令
+* `libertybans.alts.autoshow` - 当检测到玩家试图开小号登录时收到通知
+* `libertybans.alts.accounthistory.list` - /accounthistory 列表
+* `libertybans.alts.accounthistory.delete` - /accounthistory delete 列表
+
+## 管理员
+
+* `libertybans.admin.debug` - /libertybans debug
+* `libertybans.admin.reload` - /libertybans reload
+* `libertybans.admin.restart` - /libertybans restart
+* `libertybans.admin.addon` - /libertybans addon
+* `libertybans.admin.import` - /libertybans import
+* `libertybans.admin.viewips` - 如果在配置中开启了*censor-ip-addresses*，则允许所有管理员查看玩家的 IP 地址。
+
+### Scopes
+
+If scope permissions are enabled, additional permissions are required to punish and list punishments. See the [Scoped Punishments](Scoped-Punishments.md) page.
+
+## 附加功能
+
+附加功能的具体权限在 [附加组件](Addons) 页面上有说明。
+
+# LibertyBans 0.8.x
+
+在 0.8.x 中，封禁、禁言、警告和踢除的权限都遵循此模板：
+
+* `libertybans.ban.command` - required as a prerequisite for banning
+* `libertybans.ban.ip` - required for banning _IPs_
+* `libertybans.ban.undo` - required as a prerequisite for unbanning
+* `libertybans.ban.undoip` - required for unbanning _IPs_
+* `libertybans.ban.silent` - use the silent feature for bans (e.g. `ban -s`)
+* `libertybans.ban.silentundo` - use the silent feature for unbans (e.g. `unban -s`)
+* `libertybans.ban.notify` - receive notifications for bans
+* `libertybans.ban.unnotify` - receive notifications for unbans
+* `libertybans.ban.notifysilent` - receive notifications for all bans, even those executed with "-s"
+* `libertybans.ban.unnotifysilent` - receive notifications for all unbans, even those executed with "-s"
+
+Replace `ban` with `mute`, `warn`, or `kick` for permissions relevant to other punishment types.
+
+Duration permissions are the same as in 1.0.0.
+
+另请参阅 [从 0.8.x 升级至 1.0.0](Upgrading-to-LibertyBans-1.0.0-from-0.8.x)

--- a/docs/zh-cn/Plugin-Comparison-Conclusions.md
+++ b/docs/zh-cn/Plugin-Comparison-Conclusions.md
@@ -1,0 +1,78 @@
+
+Clearly, the advice here will tell you to use LibertyBans.
+
+Nevertheless, it's useful to know why. This page derives conclusions from the comparisons to each individual plugin:
+* [Comparison to AdvancedBan](Comparison-to-AdvancedBan)
+* [Comparison to BanManager](Comparison-to-BanManager)
+* [Comparison to LiteBans](Comparison-to-LiteBans)
+
+### Terminology
+
+We will repeatedly refer to *correctness* and *reliability*.
+
+*Correctness* means a plugin implements the correct intended behavior. It doesn't mean the plugin is free of bugs; rather, that the plugin is designed to work correctly. If a plugin is not designed to work correctly, that is an intentional failing of the plugin.
+
+*Reliability* refers to whether the plugin is known to fail in specific scenarios. If a plugin acts unpredictably, it is unreliable. If the plugin works most of the time, but has bugs which occur very rarely, it is unreliable.
+
+### Disclaimer
+
+Please note that no harm is meant to subjects of criticism. If the writing sounds harsh, we apologize; please let us know and we will make the language less harsh.
+
+## Why not AdvancedBan
+
+If you read the comparison to AdvancedBan, then I believe the reasons why not to use AdvancedBan should be sufficiently clear.
+
+AdvancedBan suffers from design and implementation issues which cannot be fixed without dramatically rewriting most of AdvancedBan.  At that point, you might as well use a different plugin than wait for a rewrite of AdvancedBan. A rewrite would effectively create a new plugin anyway.
+
+Reasons to use AdvancedBan over LibertyBans<sup>*</sup>
+* You absolutely need to use Java 8 and cannot upgrade
+* You absolutely need to use MariaDB or MySQL, and you absolutely need to use an old database version.
+
+<sup>* Consider using BanManager before AdvancedBan; see below</sup>
+
+The problems with AdvancedBan regard its *correctness* and *reliability*. Correctness and reliability are more important than features, we do not recommend using AdvancedBan in any other case.
+
+## Why not BanManager
+
+Firstly, if you plan to run a commercial server or network, it is **illegal** for you to use BanManager. Otherwise, keep reading. <sub>Disclaimer: This not legal advice and the writer is not a lawyer</sub>
+
+Unlike AdvancedBan, BanManager does not suffer from problems of correctness and reliability. BanManager's schema is sufficiently robust so that, even if there are bugs in BanManager, such bugs will not corrupt the database data.
+
+However, BanManager still has its own structural issues. These issues cannot be solved without drastic changes to BanManager. As such, we recommend LibertyBans.
+* If you are a developer, you may find working with BanManager more difficult, because the API is not clearly defined and is statically accessed.
+* With respect to codebases, we find that LibertyBans has better code quality, which suggests BanManager will experience more bugs as updates are released.
+
+Moreover, we judge that LibertyBans prioritizes bugs to a greater extent than in BanManager. BanManager is more likely to work on new features than fix existing bugs:
+* As of this writing, there are multiple open issues with the "bug" label on the BanManager issue tracker; however, BanManager is working on significant new features rather than solving these bugs (such as Velocity support and moving to Gradle as the build system).
+* In contrast, it is a stated policy of LibertyBans that solution of bugs will be prioritized over new features.
+
+A good reason to use BanManager would be if you absolutely needed to use Java 8, since LibertyBans does not support Java 8. Other good reasons to use BanManager would be that you require specific features not found in LibertyBans.
+
+## Why not LiteBans
+
+Most importantly, LiteBans is proprietary and closed-source. The developer team consists of a single individual, and the plugin jar is obfuscated. If LiteBans were ever to halt development, or the author to vanish, the whole plugin would have to be rewritten from scratch, because the source code could not be recovered.
+
+Due to LiteBans' proprietary nature, even simple updates and bug fixes must wait for the lone author. Contrast this to LibertyBans, which has two official maintainers, A248 and Simon. If one of them is absent, LibertyBans can still receive critical bug fixes such as updates to newer Minecraft versions, which has happened before.
+
+As a further consequence, it is impossible for us to fully audit LiteBans. We cannot make any hard conclusions regarding the LiteBans codebase. It may be wholly *incorrect* or *unreliable*. We can't say. LiteBans might break down in specific situations, or fail silently in some cases. Or it might run fine all the time. LiteBans might have security vulnerabilities from using H2, a database which has [a history of vulnerabilities](https://www.cvedetails.com/vulnerability-list.php?vendor_id=17893&product_id=45580). We'll never know.
+
+There are other reasons not to use LiteBans. Evidence suggests LiteBans does not employ automated testing much, increasing the prevalence of bugs in releases. Moreover, its database schema does not utilize integrity constraints, which can lead to data corruption. Yet because accessing the database is recommended over API use, LiteBans has to keep backwards compatibility with its backwards database, hindering development.
+
+Features that languish on the LiteBans issue tracker will stay incomplete until the author decides to add them. No one else can contribute them or prioritize them. Even if a feature is heavily demanded, only the LiteBans author decides. As of 11 September 2023, the following LiteBans feature requests are fully implemented by LibertyBans:
+* [Define scopes in punishment templates](https://gitlab.com/ruany/LiteBans/-/issues/502)
+* [Extend punishment duration](https://gitlab.com/ruany/LiteBans/-/issues/494)
+* [Purge a punishment completely](https://gitlab.com/ruany/LiteBans/-/issues/494) (same link)
+* [Server scope groups](https://gitlab.com/ruany/LiteBans/-/issues/452)
+* [Default reason for kicking](https://gitlab.com/ruany/LiteBans/-/issues/406)
+* [Tab complete offline player names](https://gitlab.com/ruany/LiteBans/-/issues/349)
+* [Add /ipkick command](https://gitlab.com/ruany/LiteBans/-/issues/301)
+* [Confirmation for /staffrollback](https://gitlab.com/ruany/LiteBans/-/issues/185)
+* [Notification permissions per punishment type](https://gitlab.com/ruany/LiteBans/-/issues/130)
+* [Support Sponge platform](https://gitlab.com/ruany/LiteBans/-/issues/41)
+* [Import vanilla IP bans](https://gitlab.com/ruany/LiteBans/-/issues/22)
+
+For developers, the LiteBans API is poorly defined and commonly cited as a pain to work with. This makes it harder to integrate other plugins with LiteBans, unless the developer resorts to brittle command execution, forfeiting API guarantees. Not to mention that the inability to look at method implementations shackles debugging attempts. The API does not fully follow semantic versioning, either.
+
+Ultimately, little information is known about LiteBans. In fact, it may even be illegal for us to disclose the results of our investigation into the workings of LiteBans.
+
+Imagine one day that you find a very complex bug and track it down to LiteBans. Complex bugs arising from multiple plugins need not even be LiteBans' fault, but they can still exist because of the presence of LiteBans. Sometimes, a bug is dependent on the most extraneous circumstances. However, with LiteBans, we'd have a case of [The Bug Nobody is Allowed to Understand](https://www.gnu.org/philosophy/bug-nobody-allowed-to-understand.en.html).

--- a/docs/zh-cn/Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings.md
+++ b/docs/zh-cn/Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings.md
@@ -1,0 +1,54 @@
+
+This page explains how punishments are enforced. I'll use bans as an example, but the same can be said for mutes.
+
+Punishment enforcement depends on the `address-strictness` setting you configure.
+
+## Choosing an Address Strictness
+
+The default address strictness is `NORMAL`. The behavior in other punishment plugins is similar to `LENIENT` in LibertyBans.
+
+For large servers, there are also [performance considerations](Database-Performance) to choosing the strictness.
+
+## User Ban
+
+On lenient, normal, or stern address strictness:
+* The ban applies only to the target user. That user may change their name, but they will still be banned according to their UUID.
+
+On strict strictness, user bans are treated as if IP bans.
+
+## IP Bans
+
+Behavior depends on the strictness configured.
+
+### Lenient strictness
+
+This is the same behavior as most punishment plugins. It is also the most intuitive.
+
+When using "lenient" strictness, IP bans apply to:
+ * Users joining with the banned IP address
+
+### Normal strictness
+
+This is the default option. It is designed to eliminate loopholes (e.g., player changes their IP address) and limit the usage of alt accounts (using another account to bypass a ban). This mechanism is effective enough to eliminate the need for an alt-check plugin.
+
+When using "normal" strictness, IP bans apply to:
+ * Users joining with the banned IP address
+ * Users who have previously joined with the banned IP address
+
+### Stern strictness
+
+The "stern" option is the most effective. Arguably it is too severe, which is why it is not the default.
+
+When using "stern" strictness, IP bans apply to:
+ * Users joining with the banned IP address
+ * Users who have previously joined with the banned IP address
+ * Users who have previously joined with an IP address which the user who is banned has also joined with
+
+### Strict strictness
+
+This setting includes the additional stipulation that user bans are enforced as stringently as IP-bans.
+
+When using "strict" strictness, **user and IP bans** apply to:
+* Users joining with the banned UUID or IP address
+* Users who have previously joined with the banned IP address
+* Users who have previously joined with an IP address which the user who is banned has also joined with

--- a/docs/zh-cn/Quick-Plugin-Comparison.md
+++ b/docs/zh-cn/Quick-Plugin-Comparison.md
@@ -1,0 +1,156 @@
+This is a quick table for comparing between LibertyBans, AdvancedBan, BanManager, and LiteBans.
+
+**NB: *Tables and graphs do not tell the full picture!*** To really understand what's going on here, read the detailed and explanatory 
+comparisons. You can find these on the sidebar at the right. For each plugin here, there is a detailed comparison between LibertyBans and the plugin.
+
+## Table
+
+<!-- Platform logos -->
+
+[Bukkit]:https://media.forgecdn.net/avatars/97/684/636293448268093543.png
+[Sponge]:https://www.spongepowered.org/favicon.ico
+
+<!-- License logos -->
+
+[AGPL]:https://www.gnu.org/graphics/agplv3-155x51.png
+[GPL]:https://www.gnu.org/graphics/gplv3-127x51.png
+[CC-BY-NC]:http://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc.png
+
+| Plugin      | Supported Platforms                                                                                                                                                                                                                                                                                                                                                      | Java Req. | Free (Gratis) | Open License               | Databases Available                        | Thread-Safe Design | Stable API | Geyser Support | Multi-Instance Support | Connection Pool | Exemption | Server Scopes | Layouts / Templates | Uses UUIDs | Schema Integrity | Switch Storage Backends | Import From                                                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|---------------|----------------------------|--------------------------------------------|--------------------|------------|----------------|------------------------|-----------------|-----------|---------------|---------------------|------------|------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| LibertyBans | ![Bukkit]Bukkit<br/> <img src="https://avatars.githubusercontent.com/u/1007849?v=4" width=16>Bungee<br/> <img src="https://www.spongepowered.org/assets/img/icons/spongie-mark.svg" width=16>Sponge <img src="https://raw.githubusercontent.com/PaperMC/velocitypowered.com/5878ae0941e3adff3a238fe9020250c5f01c2899/src/assets/img/velocity-blue.png" width=16>Velocity | 17+       | ✔️            | ✔️ ![AGPL]                 | HSQLDB (local), MariaDB, MySQL, PostgreSQL | ✔️                 | ✔️         | ✔️             | ✔️                     | ✔️              | ✔️        | ✔️            | ✔️                  | ✔️         | ✔️               | ✔️                      | AdvancedBan<br/>BanManager<br/>LiteBans<br/>vanilla                                                                                                |
+| AdvancedBan | ![Bukkit]Bukkit<br/> <img src="https://avatars.githubusercontent.com/u/1007849?v=4" width=16>Bungee                                                                                                                                                                                                                                                                      | 8+        | ✔️            | ✔️ ![GPL]                  | HSQLDB (local), MariaDB, MySQL             | ❌️                 | ❌️         | ❓              | ❌️                     | ❌️              | ✔️        | ❌️            | ✔️                  | ➖️         | ❌️               | ❌️                      |                                                                                                                                                    |
+| BanManager  | ![Bukkit]Bukkit<br/> <img src="https://avatars.githubusercontent.com/u/1007849?v=4" width=16>Bungee<br/> <img src="https://www.spongepowered.org/assets/img/icons/spongie-mark.svg" width=16>Sponge                                                                                                                                                                      | 8+        | ✔️            | ➖️️ ![CC-BY-NC]            | H2 (local), MariaDB, MySQL                 | ❌️️                | ❌️         | ➖️️            | ✔️                     | ✔️              | ❌️        | ➖️            | ➖️                  | ✔️         | ✔️               | ➖️                      | AdvancedBan<br/>vanilla                                                                                                                            |
+| LiteBans    | ![Bukkit]Bukkit<br/> <img src="https://avatars.githubusercontent.com/u/1007849?v=4" width=16>Bungee<br/> <img src="https://raw.githubusercontent.com/PaperMC/velocitypowered.com/5878ae0941e3adff3a238fe9020250c5f01c2899/src/assets/img/velocity-blue.png" width=16>Velocity                                                                                            | 8+        | ❌️            | ❌️ Proprietary, Obfuscated | H2 (local), MariaDB, MySQL, PostgreSQL     | ❓                  | ➖️         | ➖️️            | ✔️                     | ❓               | ➖️        | ➖️            | ✔️                  | ✔️         | ❌️               | ✔️                      | AdvancedBan<br/>BanManager<br/>LibertyBans➖️<br/>vanilla<br/>*+4 abandoned*<img src="https://clipart-library.com/data_images/508362.png" width=20> |
+| vanilla     | ![Bukkit]Bukkit<br/> <img src="https://www.spongepowered.org/assets/img/icons/spongie-mark.svg" width=16>Sponge                                                                                                                                                                                                                                                          | NA        | ✔️            | ❌️ Proprietary             | Flatfile                                   | ✔️                 | ✔️         | ✔️             | ❌️                     | NA              | ❌️        | ❌️            | ❌️️                 | ✔️         | ❌️               | NA                      |                                                                                                                                                    |
+
+Legend:
+
+✔️ – Yes
+
+➖️ – Partially
+
+❌️ – No
+
+❓ - Unknown, either because the plugin is closed-source, or the feature has not been tested.
+
+NA - Not applicable
+
+### Why does LibertyBans check all the boxes?
+
+It didn't used to. This chart was created when LibertyBans didn't have multi-instance support, exemption, server scopes, layouts, or switching storage backends. With this exception of layouts and switching storage, all these features were listed in the table, but they were unimplemented and unrequested -- with no plans to add them! Back then, LibertyBans used to receive ❌️ or ➖️ in many areas.
+
+Over time, features were requested and implemented, so LibertyBans fulfills these categories now and receives ✔️. Competitor plugins still have capabilities not found in LibertyBans, but they aren't deemed sufficiently important or central to the purpose of punishment to have a place on the table.
+
+How do we know the features listed in the table are sufficiently important and central to the purpose of a punishment plugin? Well, in most cases, we *predicted* which features would be most important, so we placed them in the table. The predictions turned out to be correct, since the categories in the table were the most popular feature requests.
+
+## Categories
+
+Some categories require further explanation because they are not self-explanatory. They are described here.
+
+Some categories are too complex to describe here. When this is the case, it is necessary to read the detailed plugin-by-plugin comparisons. You can find these on the sidebar at the right. For each plugin here, there is a detailed comparison between LibertyBans and the plugin.
+
+### Supported Platforms
+
+Which platforms are supported by a stable release of the plugin.
+
+### Java Requirement
+
+The minimum Java version needed to run the software.
+
+### License
+
+Whether the software is under a free software license. Requirements:
+1. Freedom of source code: the software is open-source
+2. Freedom of use: the user can use the software for whatever purpose
+
+BanManager's license prohibits commercial use. This makes it **illegal** to use BanManager for monetary profit. However, it is open-source; hence the "partial" ranking.
+
+LiteBans is obfuscated, meaning its plugin jar is intentionally scrambled to prevent anyone from inspecting its operations, debugging issues, or making any sort of modification.
+
+Disclaimer: This is not legal advice and the writer is not a lawyer.
+
+### Thread-Safe Design
+
+If a plugin is not thread-safe, it will have unreliable and buggy behavior. However, some of this unreliable behavior may only occur in exceptional and rare circumstances, making it very hard to debug and diagnose.
+
+See the detailed plugin-specific comparisons for more information.
+
+### Stable API
+
+Whether the plugin's API is semantically-versioned and therefore can be relied upon in stable fashion by other plugins.
+
+See [semver.org](https://semver.org/) and the detailed plugin-specific comparisons.
+
+LiteBans' *partial* ranking: LiteBans follows the semver constraint of restricting breaking changes to major versions, but does not follow semver for additions of new API, which *should* be done in minor releases.
+
+### Geyser Support
+
+Whether the plugin is compatible with Geyser/Floodgate, a plugin which allows Bedrock Edition players to join the server or proxy by changing usernames.
+
+LiteBans' *partial* ranking: LiteBans claims Geyser compatibility, but its documentation suggests the period character is the only supported prefix for Bedrock usernames.
+
+### Multi-Instance Support
+
+This feature allows synchronizing punishments across multiple instances of the given plugin. It is relevant for proxies.
+
+This is commonly used for multi-proxy setups, but can also be used for installing the plugin on the backend servers rather than the proxy.
+
+### Connection Pool
+
+Includes whether the plugin has a connection pool *and* takes advantage of it.
+
+AdvancedBan has a connection pool, but in practice, can only use 1 connection at a time, which is effectively the same as not using a connection pool.
+
+### Exemption
+
+Whether the plugin can prevent lower-ranked staff from banning higher-ups through a system of exemption levels.
+
+BanManager's *no* ranking: While BanManager has a basic exemption feature without levels, it requires every exempted player to be written out in the BanManager configuration. This is far too inconvenient in many cases, since it requires reconfiguring and reloading BanManager every time staff are promoted.
+
+LiteBans' *partial* ranking: The plugin does not support arbitrary levels of exemption.
+
+### Server Scopes
+
+This feature is relevant for proxies. Whether the plugin has the ability to define "scopes" and create punishments applying to certain scopes. This allows server administrators to create punishments applying to a specific backend server or a group of backend servers.
+
+BanManager's and LiteBan's *partial* ranking: BanManager has the ability to create a "local" punishment, meaning it applies to one backend server. However, it does not have the ability to define punishments applying to a group of backend servers; further, local punishments cannot be created from separate servers. LiteBans has server scopes, but similarly, it cannot create scopes applying to a group of servers.
+
+### Layouts / Templates
+
+Whether the plugin can automatically fill in details such as the reason and time, including based on the past history of the punished player.
+
+BanManager's *partial* ranking: Reason shortcuts are provided; however, automatic time calculation based on past history is not implemented.
+
+### Uses UUIDs
+
+Whether the plugin stores UUIDs instead of player names, for both the targets of punishments and operators of punishments. Player names can change, so they cannot be relied upon.
+
+AdvancedBan's *partial* ranking: AdvancedBan uses UUIDs for the targets of punishments. However, it uses player names for operators.
+
+### Schema Integrity
+
+Whether the data types defined by the plugin's database schema have appropriate constraints and are of the correct type.
+
+* When a database schema has integrity, a bug in the plugin will *not* corrupt user data.
+* Otherwise, bugs in the plugin may corrupt user data.
+
+Data corruption, if it occurs, is not easy to recover from and may require manually interfacing with the database.
+
+### Switch Storage Backends
+
+Whether the user can switch between the supported database backends. This feature is also known as "self-importing."
+
+BanManager's *partial* ranking: BanManager only supports converting from H2 to MySQL/MariaDB, but it is not possible to switch back to H2.
+
+### Import From
+
+The other punishment suites this plugin can import from.
+
+LiteBans' *partial* ranking with respect to LibertyBans: LiteBans does not import server scopes, although scopes are a common feature between them.
+
+Moreover, LiteBans can import from 4 abandoned plugins: BanHammer, BungeeAdminTools, MaxBans, and UltraBans. These plugins have received no codebase updates for at least 3 years.
+
+--------------------------------------------------------------------------
+
+As a closing note, this information is kept up-to-date within a reasonable timeframe. We welcome PRs from those affiliated with other plugins to update this information when necessary.

--- a/docs/zh-cn/Running-Multiple-Instances.md
+++ b/docs/zh-cn/Running-Multiple-Instances.md
@@ -1,0 +1,38 @@
+
+This is an advanced topic which most users will not need to consider.
+
+### Motivation
+
+There are some reasons you might want to run multiple instances of LibertyBans:
+* You are running multiple proxies
+* You are running a single proxy and want LibertyBans on the backend servers for a particular reason
+
+### Multi-Instance Usage
+
+You should place LibertyBans on the backend servers, and not the proxies.
+
+LibertyBans is designed to synchronize punishments across instances, but only across multiple backend instances.
+
+## Configuration
+
+### Database
+
+Configure all instances to connect to the same database in the `sql.yml`.
+
+It is not possible to synchronize punishments using the default (local) database, HSQLDB. You need to use a remote database, such as MariaDB or PostgreSQL.
+
+### Synchronization
+
+You must also enable cross-instance synchronization in the `sql.yml`:
+  * Set `synchronization.mode` to an available setting other than 'NONE'. For example:
+```yaml
+synchronization:
+  mode: 'ANSI_SQL' # Synchronizes punishments between servers
+```
+  * More modes may be implemented upon feature request.
+
+### Current Limitations
+
+* If you kick a player who is offline, the punishment will go through. LibertyBans will allow you to "kick" offline players. The kick will be recorded in punishment history.
+
+These limitations may be removed in the future, if they garner enough attention.

--- a/docs/zh-cn/Scoped-Punishments.md
+++ b/docs/zh-cn/Scoped-Punishments.md
@@ -1,0 +1,56 @@
+
+# Scoped Punishments
+
+The server scopes feature allows you to ban players from specific backend servers on a network such as BungeeCord or Velocity.
+
+For example, perhaps you want to ban a player from the PvP server for combat hacking; however, they beg and plead until eventually convincing you to allow them to play the Creative game mode on a different backend server.
+
+Scope configuration is controlled by the `scope.yml`.
+
+## Introduction
+
+There are three kinds of scopes:
+1. The global scope, applying everywhere.
+2. Per-server scopes.
+3. Category scopes, applying to a group of servers.
+
+### Server Name
+
+The server name controls how the server itself is identified in per-server scopes. This is the same server name you configured proxy-wide: on BungeeCord, in the `config.yml`, and for Velocity, the `velocity.toml`.
+
+Usually, backend servers can automatically detect their server name (using a technique called plugin messaging). However, if automatic detection is insufficient, you can override the detected server name.
+
+On the proxy, LibertyBans will always know each backend server's name. The proxy *itself* can also be named by setting a value manually, although per-proxy punishments have limited practical use.
+
+### Categories
+
+Categories may be configured per-server. Simply write out the categories it will be included in.
+
+## Commands
+
+Scopes may be used in commands by specifying `-server=<server>` with a server name, `-category=<category>` with a category, or `-scope=<scope>` with *any* scope.
+
+With `-scope=<scope>`, the scope itself must be one of `server:<server>`, `category:<category>` or `*` for the global scope. For example, `-scope=category:pvp` is valid.
+
+### Punish commands
+
+If no scope is specified, punishing commands will use the configured default punishing scope. You may change this to the current server to ban players on the same server by default.
+
+### Listing commands
+
+Listing commands such as /banlist, /history, etc. will include punishments from all scopes. Specifying a scope will narrow the list of punishments to ones using that scope -- critically, this is NOT the same as punishments *applying* to that scope. For example, `/banlist -scope=*` will yield only punishments with the global scope, but will not show punishments with per-server or category scopes.
+
+### Examples
+
+* /ban A248 -server=lobby You're just too annoying in the lobby
+* /mute A248 -category=clans A conversationalist is far too dangerous of a clans player
+* /warn A248 -scope=* 7d It's possible to place the -server, -category, or -scope argument anywhere before the punishment reason
+* /kick A248 Did you know that scoped kicks work too? The player will only be kicked if they're currently connected to the given scope
+
+### Permissions
+
+By default, permissions for scopes are disabled for compatibility. To require specific permissions, turn on `require-scope-permissions`.
+
+If enabled:
+* Staff must have the `libertybans.scope.global`, `libertybans.scope.server.<server>`, or `libertybans.scope.category.<category>` permissions.
+* The permission `libertybans.scope.default` must be granted to use commands without a scope argument. Not granting this permission requires staff members to specify an explicit scope.

--- a/docs/zh-cn/Self-Importing.md
+++ b/docs/zh-cn/Self-Importing.md
@@ -1,0 +1,16 @@
+
+LibertyBans allows you to switch storage backends by importing its own data.
+
+This is accomplished by simply copying all the data from the old database to the new database.
+
+# Self-Importing Steps
+
+1. Backup your data. Taking backups is good practice, *always*. If you want to be extra safe, be sure that you can restore your backup, too.
+2. Configure the `import.yml` with the *old database* to import from.
+3. Obtain a fresh, clean database -- the *new database* you want to use. Configure the `sql.yml` with this new database.
+4. Restart LibertyBans with `/libertybans restart` and then run `/libertybans import self`.
+5. Wait for the self-import process to complete. Don't join the server yet.
+
+The new database **MUST** be empty before you run the self-import process. If the new database already has data in it, the migration is very likely to fail.
+  * **This means you cannot join the server until the self-import process is complete**, since joining the server will add data to the database.
+  * This also means you cannot create punishments on the new database before importing.

--- a/docs/zh-cn/Silent-Punishments.md
+++ b/docs/zh-cn/Silent-Punishments.md
@@ -1,0 +1,25 @@
+Normally, when you punish or unpunish a player, two messages are sent:
+
+1. A message to the player running the command, telling them it was successful
+2. A message to all other players with a certain permission, telling them a player was punished or unpunished.
+
+This second message is called the notification message. It is usually sent to staff members.
+
+## Silent Messages
+
+The `-s` option allows punishing or unpunishing a player silently. A silent message does not show the notification message.
+
+For example:
+* `ban -s A248 You are banned`
+* `ban A248 30d -s Banned for 30 days`
+* `unban A248 -s`
+
+As shown in these examples, `-s` can come anywhere before the punishment reason.
+
+## Controlling the Silent Feature
+
+* Only players with the permission `libertybans.<type>.silent` or `libertybans.<type>.silentundo` can use the silent feature.
+* Staff members with the permission `libertybans.<type>.notifysilent` or `libertybans.<type>.unnotifysilent` will always see notification messages, regardless of whether `-s` was used.
+where `<type>` is the punishment type like 'ban' or 'mute'
+
+See the [Permissions](Permissions) page for more information.

--- a/docs/zh-cn/The-Database-Schema.md
+++ b/docs/zh-cn/The-Database-Schema.md
@@ -1,0 +1,160 @@
+If you are implementing a web frontend for the LibertyBans database, or otherwise need to connect to the database schema, some things are helpful to know.
+
+Terminology: Throughout this page the adjective terms "standard-compatible", "SQL standard", and "standard" are used to refer to SQL syntax, features, or behavior which is in accordance with the ANSI SQL standard.
+
+Notice: This page documents the schema of LibertyBans 1.0.0. The schema for 0.8.x is similar, but more minimal, and somewhat less normalized: some of the information here does not apply.
+
+## Requirements
+
+LibertyBans needs to run using MariaDB, MySQL, or PostgreSQL. Local storage options (HSQLDB) do not work because they only allow connections from the same process.
+
+## Recommendations
+
+### Write Standard SQL
+
+Since PostgreSQL, MariaDB, and MySQL are quite different in terms of vendor-specific syntax, it is strongly suggested to maintain standard SQL in your code. That way, your program will work on whichever database users happen to choose. Sometimes, however, this may not be possible.
+
+### Use Quoted Identifiers
+
+It is required to use quotes around table and column names. If you do not do this, your SQL queries may fail because some column names are reserved keywords (for example, the `name` column in `libertybans_names`). The rest of this page will show you SQL without quoted identifiers, but it is expected that you quote your own SQL 
+
+For MariaDB and MySQL, you should enable ANSI quotes, and other ANSI SQL behavior, using the sql_mode variable:
+* `SET @@SQL_MODE = CONCAT(@@SQL_MODE, ',ANSI');`
+* This variable is scoped to the client session. You will need to run the above query every time you open a new connection. Connection pooling libraries should offer this functionality - I know HikariCP (Java) and sqlx (Rust) both do.
+
+### Do Not Blindly Copy and Paste
+
+it is expected that you do not blindly copy and paste from the examples. The examples do not use quoted identifiers. Also, their purpose is tailored to a specific topic, and may have little practical value otherwise.
+
+## Types
+
+### Binary UUIDs
+
+All UUIDs are stored as either BINARY(16) or UUID, depending on the database type. This differs from some other plugins which store UUIDs as text.
+
+* In MariaDB and MySQL, BINARY is used:
+  * To convert from CHAR to BINARY, use `HEX`:
+    * Note that this requires a UUID without dashes.
+    * Example: `SELECT HEX('ed5f12cd600745d9a4b9940524ddaecf') FROM DUAL`
+  * To convert from BINARY to CHAR, use `UNHEX`:
+    * The returned string will not have dashes.
+    * Example: `SELECT UNHEX(uuid) FROM libertybans_names WHERE name = ?`
+  * Be careful to avoid full table scans: Inside `WHERE` clauses, you should place the HEX or UNHEX function on the value, not the column:
+    * Do this: `SELECT name FROM libertybans_names WHERE uuid = HEX('ed5f12cd600745d9a4b9940524ddaecf')`
+    * Do NOT this: `SELECT name FROM libertybans_names WHERE UNHEX(uuid) = 'ed5f12cd600745d9a4b9940524ddaecf'`
+* For PostgreSQL, UUIDs are stored as UUID. UUIDs cannot be retrieved as binary; instead, you will need to compare and retrieve them as strings. See also the [PostgreSQL documentation on UUIDs](https://www.postgresql.org/docs/current/datatype-uuid.html).
+
+## Binary IP Addresses`
+`
+IP addresses are stored as VARBINARY(16) or BYTEA, depending on the database type. For an IPv4 address, 4 bytes are used; for IPv6, 16 bytes.
+
+* VARBINARY is used for MariaDB and MySQL whereas BYTEA is used on PostgreSQL.
+* On the JVM, you can use `InetAddress.getByAddress(bytes)` to obtain an `InetAddress` from a binary representation.
+
+## Tables
+
+You may use any database tool of choice to see the tables created.
+
+### Table Information
+
+Details about certain tables and their columns are described here. Some columns in certain tables either do not have an immediately clear meaning, or require additional information to use correctly.
+
+Although MariaDB and PostgreSQL support dialect-specific forms of creating comments on columns, LibertyBans does not use non-standard commenting features. Instead, the meanings of these columns are documented here.
+
+* For the table `libertybans_punishments`, notable columns:
+  * `id` - When inserting into this column, values should be retrieved from the sequence `libertybans_punishment_ids`
+  * `type` - The punishment type. 0 for bans, 1 for mutes, 2 for warns, 3 for kicks.
+  * `operator` - The operator UUID. The zero-valued UUID, a UUID of all zero bytes, represents the console.
+  * `start` - a unix timestamp, in seconds, of when the punishment was created
+  * `end` - a unix timestamp, in seconds, of when the punishment will end. We guarantee that `end > start`.
+* For tables of the form `libertybans_<type>` (the type is 'bans', 'mutes', 'warns', or 'history'):
+  * The tables bans, mutes, and warns store active punishments for their respective punishment types.
+  * The history table stores all punishments, active and inactive. It is also the only place where kicks are located, since kicks are never active.
+  * Columns:
+    * `id` - foreign key pointing to the punishment id in `libertybans_punishments`
+    * `victim` - foreign key pointing to the victim id in `libertybans_victims`
+  * Constraints: For the bans and mutes tables, the victim must be unique. The reason is that there can only be one active ban or active mute for any particular victim.
+* For the table `libertybans_victims`:
+  * The data in this table is used by the tables storing punishments.
+  * Columns:
+    * `id` - When inserting into this column, values should be retrieved from the sequence `libertybans_victim_ids`
+    * `uuid` and `address` - The meaning and presence of these columns is dependent on the value of the `type` column. Together, they comprise the data representing a victim. They are UUIDs or IP addresses.
+    * `type` - the kind of victim which is punished. Possible values and their meanings:
+      * `0` - a UUID. `uuid` will be the UUID of the banned player. `address` is unspecified. Corresponds to `VictimType.PLAYER` from the Java API.
+      * `1` - an IP address. `address` will be the banned IP address. `uuid` is unspecified. Corresponds to `VictimType.ADDRESS` from the Java API.
+      * `2` - a composite UUID and IP address combination. `uuid` will be the banned UUID and `address` will be the banned IP address. Corresponds to `VictimType.COMPOSITE` from the Java API.
+* For the tables `libertybans_names` and `libertybans_addresses`:
+  * `updated` - a unix timestamps, in seconds, of when the record was created or last updated. In other words, this tells you how up-to-date the entry is.
+  * `libertybans_addresses`.`address` - a IPv4 or IPv6 address, guaranteed to be either 4 or 16 bytes long.
+
+### Views
+
+The "simple_" views will help you avoid writing repetitive JOINs. The views are perfect for when you need easily displayable information.
+
+* The `libertybans_simple_<type>` views are the result of joining the `libertybans_punishments`, `libertybans_<type>`, and `libertybans_victims` tables, by punishment ID and victim ID:
+  * For example, `liberybans_simple_bans` is the result of joining libertybans_punishments, libertybans_bans, and libertybans_victims.
+  * These views will render as an easily accessible table with id, type, victim_type, victim_uuid, victim_address, operator, reason, scope, start, and end columns.
+  * The `victim_type`, `victim_uuid`, and `victim_address` columns have the same meaning as the `type`, `uuid`, and `address` columns from the `libertybans_victims` table.
+  * The other columns have the same meaning as the columns in the `libertybans_punishments` table.
+  * The `libertybans_simple_active` view is a `UNION` of libertybans_simple_bans, libertybans_simple_mutes, libertybans_simple_end
+  * Remember to check time-based expiration when you select from these views.
+* The `libertybans_simple_history` view is very similar. However, it contains all punishments, not just active punishments.
+
+### Checking Expiration
+
+When selecting active punishments, it is necessary to exclude those punishments which are expired.
+
+To do this, first obtain the current timestamp - a unix timestamp, in seconds. This timestamp is the current time.
+
+Then, add a WHERE predicate to exclude expired punishments:
+* `WHERE end = 0 OR end > currentTime` where currentTime is your timestamp (in practice, it is suggested to use bind variables).
+  * Explanation: If `end` is `0`, the punishment is permanent. If `end` is greater than the current time, the punishment is temporary but has not yet expired.
+
+### Sequences
+
+You may be familiar with AUTO_INCREMENT in MariaDB/MySQL, SERIAL in PostgreSQL, or GENERATED BY DEFAULT AS IDENTITY in other RDMSes.
+
+The standard-compatible<sup>1</sup> alternative to these dialect-specific features is *sequences*.
+
+LibertyBans has the following sequences:
+* `libertybans_punishment_ids` - used to generate punishment IDs. Returns BIGINT
+* `libertybans_victim_ids` - used to generate victim IDs. Returns INT
+
+* For MariaDB, use the standard `NEXT VALUE FOR` to obtain the next value for a sequence. To retrieve the last sequene value generated in the client session, use `PREVIOUS VALUE FOR`. See also the [MariaDB docs on sequences](https://mariadb.com/kb/en/create-sequence/)
+* For PostgreSQL, `NEXTVAL` has to be used, because PostgreSQL does not support the standard syntax. See the [PostgreSQL docs on sequences](https://www.postgresql.org/docs/current/functions-sequence.html)
+* MySQL does not support sequences at all. For MySQL, LibertyBans emulates sequenes using the following strategy:
+  * Instead of using a sequence, a table is created with the same name. This will be called the emulation table.
+  * The emulation table has a single row, and a single column of importance - the `value` column. The `value` column stores the value of the sequence.
+  * To increment the sequence value (emulating `NEXT VALUE FOR` / `NEXTVAL`):
+    1. Select the current value into a variable.
+    2. Increment the sequence value.
+    3. Use the value of the variable from the first step.
+  * To obtain the current sequence value (emulating `PREVIOUS VALUE FOR` or `CURRVAL`) you will need to store, in your program, the last value you received from your sequence.
+  * To maintain integrity, all interactions with sequences should be done inside transactions, with a transaction isolation level of at least READ_COMMITTED.
+
+Here is an example of incrementing the sequence value.
+
+```sql
+SET autocommit = 0;
+
+-- Emulate NEXT VALUE FOR("libertybans_punishment_ids")
+START TRANSACTION;
+SELECT "value" INTO @@id FROM "libertybans_punishment_ids";
+UPDATE "libertybans_punishment_ids" SET "value" = "value" + 1;
+COMMIT;
+
+-- Now we may use @@id
+```
+
+<sub>1 - While GENERATED BY DEFAULT AS IDENTITY is also standard SQL, it is sadly not supported by MariaDB. Therefore, sequences are used.
+
+### Finding player names for UUIDs
+
+Use the `latest_names` view to look up the most recent known name for a UUID.
+
+## Other Information
+
+### Notes on implementation details
+
+* TINYINT data types cannot be used because they are non-standard.
+* Index names need to be unique at the database level, due to [PostgreSQL](https://stackoverflow.com/questions/27306539/at-what-level-do-postgres-index-names-need-to-be-unique)

--- a/docs/zh-cn/Upgrading-to-LibertyBans-1.0.0-from-0.8.x.md
+++ b/docs/zh-cn/Upgrading-to-LibertyBans-1.0.0-from-0.8.x.md
@@ -1,0 +1,89 @@
+
+LibertyBans 1.0.0 contains several breaking changes. This page is intended to help you migrate from 0.8.x.
+
+The upgrade should be mostly seamless and core functionality will work out of the box. No manual data migration will be necessary.
+
+## Pre-requisites and Getting Started
+
+To start with, you should be on the latest LibertyBans 0.8.x before you upgrade to 1.0.0 - currently LibertyBans 0.8.1.
+
+# Manual Action
+
+For some changes, you will need to adjust your server configuration manually.
+
+## Changes to permissions
+
+Permissions for enacting punishments (banning, muting, warning, kicking) and undoing punishments (unbanning, unmuting, un-warning) follow a more logical pattern, as described on the wiki page: [Permissions](Permissions)
+
+The difference in permissions between 0.8.x and 1.0.0 is more than a simple rename.
+  * In 0.8.x, creating an IP-ban requires the permission to IP-ban as well as the permission to ban normally. In 1.0.0, creating an IP-ban only requires the permission to IP-ban.
+  * An additional duration permission format was supported on LibertyBans 0.8.x, for backwards compatibility reasons: `libertybans.dur.ban.<timespan>` ('dur' and 'ban' are swapped). Compatibility with this format is removed in 1.0.0; the correct format is `libertybans.ban.dur.<timespan>`.
+
+## Changes to the messages.yml
+
+Some options in the messages.yml configuration have been renamed. To migrate your messages.yml easily, I suggest following this example (sourced from the Russian translation of LibertyBans): 
+
+* The `playerOrAddress` option is renamed to `player-or-address`.
+* `additions.<type>.permission.command` is now `additions.<type>.permission.uuid`. Similarly, `removals.<type>.permission.command` is now `removals.<type>.permission.uuid`.
+* `banList` is now `ban-list` and `muteList` now `mute-list`.
+
+## Databases - MariaDB and MySQL
+
+### Version Requirements
+
+If you use MariaDB or MySQL, you may need to upgrade your database server:
+* If you use MariaDB, at least MariaDB 10.3 is required. The latest MariaDB version is recommended.
+* If you use MySQL, at least MySQL 8.0 is required. MySQL 8.0 is the latest version.
+
+From LibertyBans 0.8.1 onward, older database versions are detected and a warning admonishes you in the server console.
+  * If you are on an older database version, you should have seen this warning. Nonetheless you ought to check your server console in the case you missed it.
+
+Please keep in mind that other plugins, either on account of software age or inadequacy, may be incompatible with newer database versions. It is your responsibility to ensure compatibility.
+
+### Distinction between MariaDB and MySQL
+
+It is now necessary to distinguish between MariaDB and MySQL when configuring the sql.yml:
+
+* If you use MySQL, change `rdms-vendor` in the sql.yml to `MYSQL`.
+* If you use MariaDB, no action is needed.
+
+## Multi-Instance / Multi-Proxy Support
+
+This documentation is intended for LibertyBans 0.8.2, an upcoming 0.8.x release which will add a compatibility mode.
+
+The compatibility mode will allow you to run LibertyBans 0.8.2 on the same database as 1.0.x.
+
+Until this compatibility mode is released, it is not possible to use LibertyBans 0.8.x and 1.0.x side-by-side on the same database. Therefore, you should upgrade your multi-proxy network once 0.8.2 has been made available.
+
+~~LibertyBans 0.8.2 can co-exist with LibertyBans 1.0.0 on the same database. Before beginning to upgrade to 1.0.0, you must set the option `version1-compatibility-mode` to `true` in the `sql.yml` for all your 0.8.2 LibertyBans instances.~~
+
+~~After you upgrade to 1.0.0, it is safe to remove `version1-compatibility-mode` since this option does not exist in 1.0.0~~
+
+# Automatic Action
+
+## Database Migration
+
+LibertyBans 1.0.0, when it starts, will automatically upgrade your database to 1.0.0.
+
+The database schema has breaking changes, and some software which relies on it, such as the NamelessMC punishment panel, may need to be updated.
+
+## Configuration Migration
+
+New configuration options will be added automatically.
+
+Existing configuration options will be preserved.
+
+# Other useful information
+
+## Non-Breaking Changes
+
+These changes might be useful to know.
+
+* The event scheduler feature (`mariadb.use-event-scheduler` in the sql.yml) has been removed. This feature existed solely as a minor performance optimization. If you were using this feature before, you can drop the event with `DROP EVENT IF EXISTS libertybans_refresher`
+
+## Automatic Upgrade from 0.8.x
+
+LibertyBans will not delete the 0.8.x data. If you'd like to free up disk space, you can remove the old tables.
+  * Following a successful import, the 0.8.x tables will have "zeroeight_postmigration" in their name.
+  * **Please be careful with your data**. Always take a backup before deleting large amounts of data.
+  * In HSQLDB, you would need to edit the hypersql/punishments-database.script file. This must be done while the server is stopped. Deleting the tables correctly is not trivial, so it is suggested to ask for support if necessary.

--- a/docs/zh-cn/Upgrading-to-LibertyBans-1.1.0-from-1.0.x.md
+++ b/docs/zh-cn/Upgrading-to-LibertyBans-1.1.0-from-1.0.x.md
@@ -1,0 +1,23 @@
+
+LibertyBans 1.1.0 will not break your setup and is fully compatible with 1.0.x. However, you may need to upgrade your technology or make minor configuration changes.
+
+## Java Version Requirement
+
+Java 17 is required for LibertyBans 1.1.0.
+
+If you need assistance upgrading to Java 17, we are happy to help. Please ask, but be patient.
+
+## For MariaDB Users
+
+It is highly recommended to update to at least MariaDB 10.6. Although running MariaDB 10.3-10.5 is possible, support for these older versions is deprecated and may be removed in a later release.
+
+Ultimately, you are responsible for updating your database.
+
+Performance will be slightly and unavoidably degraded when running MariaDB 10.3, 10.4, or 10.5, because LibertyBans rewrites its SQL queries to achieve compatibility with legacy vendor-specific SQL syntax.
+
+## For Floodgate Users
+
+* LibertyBans now detects Geyser/Floodgate automatically. In most cases, you no longer need to manually configure the Geyser name prefix in LibertyBans' config.yml.
+* There is one exception to automatic Geyser/Floodgate detection. If you installed LibertyBans in a different place -- for example, LibertyBans is on the proxy but Floodgate is on the backend servers -- you will need to manually configure LibertyBans to use a specified prefix. This uses a new configuration option called `force-geyser-prefix`.
+
+The `GEYSER` server-type has been removed. **You will need to update the config.yml with an appropriate `server-type`:** ONLINE, OFFLINE, or MIXED.

--- a/docs/zh-cn/Versioning-and-Support-Policies.md
+++ b/docs/zh-cn/Versioning-and-Support-Policies.md
@@ -1,0 +1,57 @@
+## Versioning
+
+LibertyBans follows semantic versioning, with some additional clarifications as to the separation between the API, server-side usage, and database schema compatibility.
+
+The format of a version is **Major**.**Minor**.**Patch**
+
+The tables indicates possible changes, and the corresponding changes to versioning. For example, `Breaking API change` corresponds to a new major version (ex: 4.0 -> 5.0), so the versioning is 'major version'.
+
+Note that the presence of a version does not necessarily mean that the changes which require that version will be present. For example, there can be a new major version without breaking schema changes.
+
+### API
+| Change                          | Versioning Change | Description                                                                                                         |
+|---------------------------------|-------------------|---------------------------------------------------------------------------------------------------------------------|
+| Breaking API change             | Major             | *Binary*-incompatible or behavior-incompatible changes to the API.                                                  |
+| Compatible API feature addition | Minor             | Backwards-binary-compatible and behavior-compatible addition to the API. May be *source*-incompatible in rare cases |
+| Implementation bug-fixes        | Patch             | Bugs fixed                                                                                                          |
+
+### Database Schema
+
+Database schema changes only matter if you are either:
+1. Running [multiple instances](Running-Multiple-Instances) of LibertyBans.
+2. Running an external program which connects to the database, for example a web interface.
+
+Assuming no external programs are connected to the database, single installations of LibertyBans do not need to be concerned with database schema changes.
+
+| Change                            | Versioning Change | Description                                                                                                                                                                                                                                                                                                                                                                    |
+|-----------------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Breaking database schema          | Major             | Past versions of LibertyBans will not be able to read or use the new schema                                                                                                                                                                                                                                                                                                    |
+| Compatible database schema change | Minor             | **The last minor release** of LibertyBans will be able to read and use the new schema. Previous minor releases of LibertyBans *may NOT* be able to read or use the new schema. For example, this means you can upgrade from 1.2.x to 1.3.x safely, but you *cannot* upgrade from 1.1.x to 1.3.x. You cannot safely have versions 1.1.x and 1.3.x co-existing at the same time. |
+
+### Server-side Usage
+| Change                              | Versioning Change | Examples                                                                           |
+|-------------------------------------|-------------------|------------------------------------------------------------------------------------|
+| Breaking server-side usage          | Major             | Command re-names, permission changes, backwards-incompatible configuration changes |
+| Compatible server-side usage change | Minor             | Permission rename, but the old permission is still supported alongside the new one |
+| Server-side usage feature addition  | Patch             | New command added, new configuration option                                        |
+
+## Support
+
+| Version                | Support Provided                                           |
+|------------------------|------------------------------------------------------------|
+| Latest released        | Always                                                     |
+| Previous minor version | At least 1 month after the next minor version is released  |
+| Previous major version | At least 4 months after the next major version is released |
+
+There is no timeline for responding to support requests, but an effort will be made to respond within 3 business days *at maximum*, ideally within 1 day.
+
+### Support for Previous Versions
+
+* You must be on the most recent version *for that version*. For example, you cannot expect support for 1.4.2 if 1.4.3 has been released.
+* Support may be slower than that for the latest version. If you are on the latest version, you are more likely to receive support *faster* and *from more users*.
+
+### A Note on Bugs in Other Software
+
+Sometimes, we identify bugs in other software which could affect LibertyBans. We may require you to fix these bugs before requesting further support.
+
+We are glad to assist you in fixing bugs on your server. The LibertyBans community is reputed for discovering, reporting, and fixing bugs in other plugins. Ultimately, however, we are only responsible for fixing our own bugs.

--- a/docs/zh-cn/_sidebar.md
+++ b/docs/zh-cn/_sidebar.md
@@ -1,19 +1,30 @@
 * 插件配置
-  * [从这开始](Getting-Started)
-  * [配置插件](Configuration)
+  * [入门](Getting-Started)
+  * [配置文件](Configuration)
   * [权限](Permissions)
-  * [JSON 信息](JSON-Messages)
-  * [Hex 颜色代码](Hex-Colors)
-  * [从宽、正常、严格的处罚执行](Punishment-Enforcement:-Lenient,-Normal,-and-Strict-settings)
-  * [静默惩处](Silent-Punishments)
-* 进阶信息 / 开发者相关
-  * [版本规则及支持](Versioning-and-Support-Policies)
+  * [JSON 消息](JSON-Messages)
+  * [Hex 颜色](Color-Codes)
+  * [惩罚类型](Punishment-Enforcement_-Lenient,-Normal,-and-Strict-settings)
+  * [悄悄封禁](Silent-Punishments)
+  * [Composite Punishments](Guide-to-Composite-Punishments)
+  * [Scoped Punishments](Scoped-Punishments)
+  * [Running Multiple Instances](Running-Multiple-Instances)
+  * [Switching Storage Backends (Self-Importing)](Self-Importing)
+  * [附加组件](Addons)
+* 版本和升级
+  * [Versioning and Support Policy](Versioning-and-Support-Policies)
+  * [从 1.0.x 升级至 1.1.0](Upgrading-to-LibertyBans-1.1.0-from-1.0.x.md) + [1.1.0 完整更新日志](Changes-in-LibertyBans-1.1.0.md)
+  * [从 0.8.x 升级至 1.0.0](Upgrading-to-LibertyBans-1.0.0-from-0.8.x) + [1.0.0 完整更新日志](Changes-in-LibertyBans-1.0.0)
+* 开发
   * [开发者 API](Developer-API)
-  * [数据库结构](The-Database-Schema)
-* 与其他插件相关
-  * [从其他插件迁移](Importing-from-Other-Plugins)
-  * [处理冲突插件的方法](Event-was-previously-blocked-by-the-server-or-another-plugin...)
-* 与其他插件作比
-  * [与 AdvancedBan 作比](Comparison-to-AdvancedBan)
-  * [与 LiteBans 作比](Comparison-to-LiteBans)
-  * [插件快速对比](Quick-Plugin-Comparison)
+  * [数据结构](The-Database-Schema)
+  * [性能优化](Database-Performance)
+* 从其他插件导入
+  * [从其他插件导入](Importing-from-Other-Plugins)
+  * [处理插件冲突](Misbehaving-Plugins)
+* 与其他插件比较
+  * [AdvancedBan](Comparison-to-AdvancedBan)
+  * [BanManager](Comparison-to-BanManager)
+  * [LiteBans](Comparison-to-LiteBans)
+  * [快速对比](Quick-Plugin-Comparison)
+  * [结论](Plugin-Comparison-Conclusions)


### PR DESCRIPTION
Hello, I'm a Chinese player, I'm very happy to have found this open source plugin, I also found that there is support for internationalization within the documentation, I really appreciate it, so I immediately translated some of the basic pages.

Note: I copied all the .md files to `zh-cn` folder and most of them has not been translated. But they can view the non-translated pages in Chinese not 404.