### PR TITLE
Fix grant check

### DIFF
--- a/bans-core/src/main/java/space/arim/libertybans/core/database/DatabaseRequirements.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/database/DatabaseRequirements.java
@@ -126,7 +126,7 @@ public final class DatabaseRequirements {
 					"SELECT", "SHOW VIEW", "TRIGGER", "UPDATE");
 			for (String requiredGrant : requiredGrants) {
 				if (actualGrants.contains(requiredGrant + ",") // not the last privilege listed
-						|| actualGrants.contains(", " + requiredGrant + " ON") /* last privilege listed */) {
+						|| actualGrants.contains(requiredGrant + " ON") /* last privilege listed */) {
 					continue;
 				}
 				LoggerFactory.getLogger(getClass()).debug("Full set of privileges detected: {}", actualGrants);


### PR DESCRIPTION
Fix #290.

The change should not change anything in regards to checking if the `GRANT` is the last one in that list, since the ` ON` should be sufficient as an indicator. However, it will also allow the rows with only one `GRANT`.