### PR TITLE
Add Japanese language file.

### DIFF
--- a/bans-core/src/main/java/space/arim/libertybans/core/config/Translation.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/config/Translation.java
@@ -31,5 +31,6 @@ enum Translation {
 	FR,
 	ZH_TW,
 	DE,
-	PL
+	PL,
+	JA
 }

--- a/bans-core/src/main/resources/lang/messages_ja.yml
+++ b/bans-core/src/main/resources/lang/messages_ja.yml
@@ -1,0 +1,498 @@
+ # 
+ # Messages configuration
+ # 
+ # 
+ # In most cases, the variables inside the default messages are those available
+ # in that specific message. The exception to this is messages which are related
+ # to a certain punishment.
+ # 
+ # When message has an associated punishment, multiple variables are available:
+ # 
+ # %ID% - punishment ID number
+ # %TYPE% - punishment type, e.g. 'Ban'
+ # %TYPE_VERB% - punishment type as a verb, e.g. 'Banned'
+ # %VICTIM% - display name of the victim of the punishment
+ # %VICTIM_ID% - internal identifier of victim
+ # %OPERATOR% - display name of the staff member who made the punishment
+ # %OPERATOR_ID% - internal identifier of the operator
+ # %UNOPERATOR% - staff member undoing the punishment. available only when the punishment is undone
+ # %UNOPERATOR_ID% - internal identifier of staff member undoing the punishment
+ # %REASON% - reason for the punishment
+ # %SCOPE% - scope of the punishment
+ # %DURATION% - original duration (how long the punishment was made for)
+ # %START_DATE% - the date the punishment was created
+ # %TIME_PASSED% - the time since the punishment was created
+ # %TIME_PASSED_SIMPLE% - the time since the punishment was created, rounded to the biggest time unit possible (e.g. 2 months instead of 1 month 23 days)
+ # %END_DATE% - the date the punishment will end, or formatting.permanent-display.absolute for permanent punishments
+ # %TIME_REMAINING% - the time until the punishment ends, or formatting.permanent-display.relative for permanent punishments
+ # %TIME_REMAINING_SIMPLE% - the time until the punishment ends, rounded to the biggest time unit possible (e.g. 10 days instead of 9 days 13 hours)
+ # %HAS_EXPIRED% - Shows if a punishments duration has run out. Does not check if the punishment is revoked!
+ # %TRACK% - the escalation track of the punishment, for example if you are using layouts
+ # %TRACK_ID% - the ID of the escalation track
+ # %TRACK_NAMESPACE% - the namespace of a track can be used by other plugins to implement their own layouts
+ # 
+ # The following variables have limited availability:
+ # %TARGET% - the original target argument of a command. For example, in '/ipban Player1', %TARGET% is Player1
+ # %NEXTPAGE% - the number of the next page of a list like history
+ # %PREVIOUSPAGE% - the number of the previous page of a list like history
+ # 
+ # 
+all:
+  usage: '&c不明なサブコマンドです。使用方法:'
+   # This section is only relevant if using the server scopes feature
+  scopes:
+    invalid: '&c無効な指定範囲: &e%SCOPE_ARG%'
+    no-permission: '&e%SCOPE%&cの範囲は使用できません。'
+    no-permission-for-default: '&c範囲を指定しなければこのコマンドは使用できません。'
+
+   # When issuing commands, if the specified player or IP was not found, what should the error message be?
+  not-found:
+    uuid: '&c&o%TARGET%&7は、有効なUUIDではありません。'
+    player: '&7&oオンラインやオフラインに&c%TARGET%&7は見当たりません。'
+    player-or-address: '&7&oオンラインやオフラインに&c%TARGET%&7は見当たらず、有効なIPでもありません。'
+
+  prefix:
+     # The prefix to use
+    value: '&6&lLibertyBans &8»&7 '
+     # If enabled, all messages will be prefixed
+    enable: true
+
+   # If a player types /libertybans but does not have the permission 'libertybans.commands', this is the denial message
+  base-permission-message: '&cこの操作は使用できません。'
+
+ # Regards /unban, /unmute, /unwarn
+removals:
+  bans:
+    usage: '&c使用方法: /unban &e<player>&c'
+    success:
+      message: '&c&o%VICTIM%&7のBANを取り消しました。'
+      notification: '&c&o%UNOPERATOR%&7によって&c&o%VICTIM%&7のBAN（アクセス禁止）が取り消されました。'
+
+    not-found: '&c&o%TARGET%&7はBANされていません。'
+    permission:
+      uuid: '&プレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+  mutes:
+    usage: '&c使用方法: /unmute &e<player>'
+    success:
+      message: '&c&o%VICTIM%&7のミュートを取り消しました。'
+      notification: '&c&o%UNOPERATOR%&7によって&c&o%VICTIM%&7のミュート（チャット禁止）が取り消されました。'
+
+    not-found: '&c&o%TARGET%&7はミュートされていません。'
+    permission:
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&CIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+  warns:
+    usage: '&c使用方法: /unwarn &e<player> <id>'
+    not-a-number: '&c&o%ID_ARG%&7は、数字ではありません'
+    success:
+      message: '&c&o%VICTIM%&7への警告を取り消しました。'
+      notification: '&c&o%UNOPERATOR%&7によって&c&o%VICTIM%&7への警告が取り消されました。'
+
+    not-found: '&c&o%ID%&7の警告を&c&o%TARGET%&7は受けていません。'
+    permission:
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+
+ # Used for /banlist, /mutelist, /history, /warns, /blame
+lists:
+  history:
+    usage: '&c使用方法: /history &e<player> [page]'
+    perPage: 10
+    layout:
+      body:
+        - '&7[&e%ID%&7] / %TYPE%&f'
+        - '&7%OPERATOR% &8/ &7%REASON% &8/ &7%START_DATE%&f'
+      footer: '&e%PAGE%&7ページ目||ttp:クリックして次のページへ||cmd:/libertybans history %TARGET% %NEXTPAGE%'
+      header:
+        - '&7[&eID&7] &8/ &7刑罰&f'
+        - '&7担当者 &8/ &7理由 &8/ &7執行日&f'
+
+    noPages: '&c&o%TARGET%&7の前歴はありません。'
+    maxPages: '&e%PAGE%&7ページ目は存在しません。'
+    permission:
+      command: '&7前歴の閲覧はできません。'
+
+
+  ban-list:
+    usage: '&c使用方法: /banlist &e[page]'
+    perPage: 10
+    layout:
+      body:
+        - '&7[&e%ID%&7] &e&o%VICTIM%&f'
+        - '&7%OPERATOR% &8/ &7%REASON% &8/ &7%TIME_REMAINING%&f'
+      footer: '&e%PAGE%&7ページ目||ttp:クリックして次のページへ||cmd:/libertybans banlist %NEXTPAGE%'
+      header:
+        - '&7[&eID&7] &e&o主な内容&f'
+        - '&7担当者 &8/ &7理由 &8/ &7執行日&f'
+
+    noPages: '&7アクティブなBANが一つもありません。'
+    maxPages: '&e%PAGE%&7ページ目は存在しません。'
+    permission:
+      command: '&7BAN一覧の閲覧はできません。'
+
+
+  mute-list:
+    usage: '&c使用方法: /mutelist &e[page]'
+    perPage: 10
+    layout:
+      body:
+        - '&7[&e%ID%&7] &e&o%VICTIM%&f'
+        - '&7%OPERATOR% &8/ &7%REASON% &8/ &7%TIME_REMAINING%&f'
+      footer: '&e%PAGE%&7ページ目||ttp:クリックして次のページへ||cmd:/libertybans mutelist %NEXTPAGE%'
+      header:
+        - '&7[&eID&7] &e&o主な内容&f'
+        - '&7担当者 &8/ &7理由 &8/ &7執行日&f'
+
+    noPages: '&7アクティブなミュートが一つもありません。'
+    maxPages: '&e%PAGE%&7ページ目は存在しません。'
+    permission:
+      command: '&7ミュート一覧の閲覧はできません。'
+
+
+  blame:
+    usage: '&c使用方法: /blame &e<player> [page]'
+    perPage: 10
+    layout:
+      body:
+        - '&7[&e%ID%&7] &e&o%VICTIM% &8 / &7%TYPE%&f'
+        - '&7%REASON% &8/ &7%START_DATE%&f'
+      footer: '&e%PAGE%&7ページ目||ttp:クリックして次のページへ||cmd:/libertybans warns %TARGET% %NEXTPAGE%'
+      header:
+        - '&7[&eID&7] &e&o主な内容 &8/ &7刑罰&f'
+        - '&7理由 &8/ &7執行日&f'
+
+    noPages: '&7プレイヤーへの刑罰を&c&o%TARGET%は執行していません。'
+    maxPages: '&e%PAGE%&7ページ目は存在しません。'
+    permission:
+      command: '&7執行人一覧の閲覧はできません。'
+
+
+  warns:
+    usage: '&c使用方法: /warns &e<player> [page]'
+    perPage: 10
+    layout:
+      body: '&7[&e%ID%&7] %OPERATOR% &8/ &7%REASON% &8/ &7%TIME_REMAINING%&f'
+      footer: '&e%PAGE%&7ページ目||ttp:クリックして次のページへ||cmd:/libertybans warns %TARGET% %NEXTPAGE%'
+      header: '&7[&eID&7] 担当者 &8/ &7理由 &8/ &7執行日&f'
+
+    noPages: '&c&o%TARGET%&7は警告を受けていません。'
+    maxPages: '&e%PAGE%&7ページ目は存在しません。'
+    permission:
+      command: '&7警告一覧の閲覧はできません。'
+
+
+
+ # Configuration for the /accounthistory command
+account-history:
+   # Pertains to /accounthistory delete <user> <timestamp>
+  delete:
+    permission: '&cアカウントの記録は消去できません。'
+    success: '&e%TARGET%&7に紐づくアカウントの記録を消去しました。'
+    usage:
+      - '&c使用方法: /accounthistory delete <user> <timestamp>'
+      - '&7時刻印はunix秒単位であり、/accounthistory listから通常は取得します。'
+    no-such-account: '&c指定した時刻印に%TARGET%のアカウント記録は残っていません。'
+
+  usage: '&c使用方法: /accounthistory <delete|list>'
+   # Regards /accounthistory list <user>
+  listing:
+     # How a single recorded account should be displayed
+     # Available variables:
+     # %TARGET% - the original input to the command
+     # %USERNAME% - the username the player connected with
+     # %ADDRESS% - the address the player connected with
+     # %DATE_RECORDED% - the date the join was recorded
+     # %DATE_RECORDED_RAW% - the raw timestamp the join was recorded
+    layout: '%USERNAME% &7(on %ADDRESS%) @ %DATE_RECORDED% (%DATE_RECORDED_RAW%)||ttp:&7保存されたアカウントをクリックして削除||cmd:/accounthistory delete %TARGET% %DATE_RECORDED_RAW%'
+     # The message to display before the account listing. Set to an empty string to disable
+    header: '&c&o%TARGET%&7に紐づくアカウントは以下のとおりです。'
+    permission: '&cアカウントの記録は閲覧できません。'
+    usage: '&c使用方法: /accounthistory list <user|ip>'
+    none-found: '&7アカウントの記録は残っていません。'
+
+
+ # Messages for alt-checks and alt account notifications
+ # 
+ # Before configuring this section, it is necessary to look at the address-enforcement
+ # settings in the main config.yml and understand the different kinds of alt detection.
+ # There is normal and strict detection.
+alts:
+   # Regarding the /alts command
+  command:
+     # The message to display atop the alt check. Set to an empty string to disable
+    header:
+      - '&c&o%TARGET%&7に紐づく代替アカウントは以下のとおりです。'
+      - '&7可能性 高 - BANされたプレイヤーとIPが同一である'
+      - '&7可能性 低 - BANされたプレイヤーが過去に利用していたアドレスで接続している'
+    permission: '&c代替アカウントの一覧は閲覧できません。'
+    usage: '&c使用方法: /alts &e<player>'
+    none-found: '&7代替アカウントは一つもない。'
+
+  auto-show:
+     # The message to display atop the alt check. Set to an empty string to disable
+    header:
+      - '&c&o%TARGET%&7は代替アカウントの可能性を否定できません。その報告は以下のとおりです。'
+      - '&7可能性 高 - BANされたプレイヤーとIPが同一である'
+      - '&7可能性 低 - BANされたプレイヤーが過去に利用していたアドレスで接続している'
+
+  formatting:
+     # The description for an alt account detected by strict detection.
+    strict: '&e可能性 低'
+     # How a single detected alt should be displayed
+     # Available variables:
+     # %DETECTION_KIND% - how the account was detected. Will be replaced by the normal or strict options.
+     # %ADDRESS% - the address in question which led to the detection
+     # %RELEVANT_USER% - the username of the other account, formatted according to the name-display option
+     # %RELEVANT_USERID% - the uuid of the other account
+     # %DATE_RECORDED% - the date the alt account was recorded
+    layout: '%RELEVANT_USER% &7(per %ADDRESS%) @ %DATE_RECORDED% - %DETECTION_KIND%'
+     # The description for an alt account detected by normal detection.
+    normal: '&c可能性 高'
+     # In the alt-check layout, the username of the alt may be formatted depending upon whether it is banned
+     # For example, the usernames of banned alts may be colored red whereas alts not banned are green
+     # Variables: %USERNAME%
+    name-display:
+      banned: '&c&o%USERNAME%'
+      muted: '&e&o%USERNAME%'
+      not-punished: '&o%USERNAME%'
+
+
+
+ # Specific formatting options
+formatting:
+   # How should punishment types be displayed?
+  punishment-type-display:
+    KICK: 'キック'
+    MUTE: 'ミュート'
+    BAN: 'BAN'
+    WARN: '警告'
+
+   # How should the %HAS_EXPIRED% variable be displayed?
+  punishment-expired-display:
+     # How do you describe an expired punishment?
+    expired: '刑期満了'
+     # How do you describe a punishment which is not expired?
+    not-expired: '刑期未了'
+
+   # When there is no more time remaining in a punishment (the punishment has expired),
+   # this becomes the value of the %TIME_REMAINING% variable
+  no-time-remaining-display: 'N/A'
+   # How should punishment types be displayed as a verb? Used for the %TYPE_VERB% variable.
+  punishment-type-verb-display:
+    KICK: 'キックされた'
+    MUTE: 'ミュートされた'
+    BAN: 'BANされた'
+    WARN: '警告を受けた'
+
+   # Controls how the %TRACK%, %TRACK_ID%, and %TRACK_NAMESPACE% variables are displayed
+  track-display:
+     # How do you describe the lack of an escalation track with respect to its namespace?
+     # The value will be displayed for the %TRACK_NAMESPACE% variable
+    no-track-namespace: '（なし）'
+     # You may wish to override the track display names. Normally the track ID is displayed,
+     # which is lowercase and stored in the database. If you want a different name to be displayed
+     # for the track, write it here.
+     # 
+     # This option affects the %TRACK% variable but not the %TRACK_ID% variable.
+    track-display-names:
+      spam: 'スパム行為'
+      hacking: '不正行為'
+
+     # How do you describe the lack of an escalation track?
+     # The value will be displayed for the %TRACK% variable
+    no-track: 'トラック無し'
+     # How do you describe the lack of an escalation track with respect to its ID?
+     # The value will be displayed for the %TRACK_ID% variable
+    no-track-id: 'トラックID無し'
+
+   # How should the console be displayed?
+  console-display: 'コンソール'
+   # How should 'permanent' be displayed as a length of time?
+  permanent-display:
+     # What do you call a permanent duration?
+    duration: '無期限'
+     # When does a permanent punishment end?
+    absolute: '永久'
+     # How do you describe the time remaining in a permanent punishment?
+    relative: '永久'
+
+   # How should the global scope be displayed?
+  global-scope-display: '全サーバー'
+   # Controls how victims are displayed
+  victim-display:
+     # In rare cases, you may have punishments for a user whose name is unknown. This can happen because
+     # users are punished by UUID, but on some configurations it is not possible to lookup player names.
+     # When this occurs, the following text is used instead of the player name.
+    player-name-unknown: '-無名-'
+     # The substitute text when an IP address cannot be viewed because the user lacks permission
+    censored-ip-address: '<IPアドレス非表示>'
+     # Whether to censor IP addresses for players without the libertybans.admin.viewips permission
+    censor-ip-addresses: false
+
+   # When using /blame, how should the console be specified?
+  console-arguments:
+    - 'console'
+   # There are 2 ways to make permanent punishments. The first is to not specify a time (/ban <player> <reason>).
+   # The second is to specify a permanent amount of time (/ban <player> perm <reason>).
+   # When typing commands, what time arguments will be counted as permanent?
+  permanent-arguments:
+    - 'perm'
+    - 'permanent'
+    - 'permanently'
+
+misc:
+   # Concerns formatting of relative times and durations
+  time:
+    fragments:
+      YEARS: '%VALUE%年'
+      MONTHS: '%VALUE%か月'
+      WEEKS: '%VALUE%週間'
+      HOURS: '%VALUE%時間'
+      MINUTES: '%VALUE%分'
+      DAYS: '%VALUE%日'
+
+    grammar:
+       # What should come before the last fragment? Set to empty text to disable
+      and: ''
+       # If enabled, places commas after each time fragment, except the last one
+      comma: false
+
+     # Times are formatted to seconds accuracy, but you may not want to display seconds 
+     # for most times. However, for very small durations, you need to display a value in seconds.
+     # If you are using SECONDS in the above section, this value is meaningless.
+    fallback-seconds: '%VALUE%秒'
+
+   # Only applicable if synchronous enforcement strategy is DENY in the main config
+  sync-chat-denial-message: '&c同期チャットが拒否されました。&7もう一度お試しください。'
+  unknown-error: '&c不明なエラーが発生しました。'
+
+ # 
+ # Messages regarding /ban, /mute, /warn, /kick
+ # Includes punishment layouts
+ # 
+ # 
+additions:
+  bans:
+    layout:
+      - '&7&lBAN（アクセス禁止）&f'
+      - '&c期間: &e%TIME_REMAINING%&f'
+      - ''
+      - '&c&l理由&f'
+      - '&7%REASON%&f'
+      - ''
+      - '&3&l異議申し立てはこちら&f'
+      - '&cWebサイト: &7website&f'
+      - '&cDiscord: &7discord'
+    usage: '&c使用方法: /ban &e<player> [time] <reason>'
+    conflicting: '&c&o%TARGET%&7はすでにBANされています。'
+    success:
+      message: '&c&o%VICTIM%&を&o%DURATION%&r&aBANしました。理由: &e&o%REASON%&a'
+      notification: '&c&o%OPERATOR%&7によって&c&o%VICTIM%&7が&a&o%DURATION%&7BAN（アクセス禁止）されました。理由: &e&o%REASON%&7'
+
+    exempted: '&c&o%TARGET%&7はBANできません。'
+    permission:
+      duration: '&e%DURATION%&cの期間では刑罰を執行できません。'
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+  mutes:
+    layout:
+      - '&7&lミュート（発言禁止）&f'
+      - '&c期間: &e%TIME_REMAINING%&f'
+      - ''
+      - '&c&l理由&f'
+      - '&7%REASON%'
+    usage: '&c使用方法: /mute &e<player> [time] <reason>'
+    conflicting: '&c&o%TARGET%&7はすでにミュートされています。'
+    success:
+      message: '&c&o%VICTIM%&aを&o%DURATION%&r&aミュート（発言禁止）しました。理由: &e&o%REASON%&a'
+      notification: '&c&o%OPERATOR%&7によって&c&o%VICTIM%&7が&a&o%DURATION%&7ミュート（発言禁止）されました。理由: &e&o%REASON%&7'
+
+    exempted: '&c&o%TARGET%&7はミュートできません。'
+    permission:
+      duration: '&c&e%DURATION%&cの期間では刑罰を執行できません。'
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+  warns:
+    layout:
+      - '&7&l警告&f'
+      - '&c期間: &e%TIME_REMAINING%&f'
+      - ''
+      - '&c&l理由&f'
+      - '&7%REASON%'
+    usage: '&c使用方法: /warn &e<player> [time] <reason>'
+    success:
+      message: '&c&o%VICTIM%&aに&o%DURATION%&r&a警告を与えました。理由: &e&o%REASON%&a'
+      notification: '&c&o%OPERATOR%&7によって&c&o%VICTIM%&7が&a&o%DURATION%&7警告を受けました。理由: &e&o%REASON%&7'
+
+    exempted: '&c&o%TARGET%&7には警告を与えられません。'
+    permission:
+      duration: '&c&e%DURATION%&cの期間では刑罰を執行できません。'
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+  kicks:
+    layout:
+      - '&7&lキック&f'
+      - ''
+      - '&c&l理由&f'
+      - '&7%REASON%'
+    usage: '&c使用方法: /kick &e<player> <reason>'
+    success:
+      message: '&c&o%VICTIM%&aをキックしました。理由: &e&o%REASON%&a'
+      notification: '&c&o%OPERATOR%&7は&c&o%VICTIM%&7をキックしました。理由: &e&o%REASON%&7'
+
+    must-be-online: '&c&o%TARGET%&7がオンラインである必要があります。'
+    exempted: '&c&o%TARGET%&7はキックできません。'
+    permission:
+      uuid: '&cプレイヤーへのその操作はできません。'
+      ip-address: '&cIPアドレスへのその操作はできません。'
+      both: '&cプレイヤーやIPアドレスへのその操作はできません。'
+
+
+
+admin:
+  addons:
+    usage: '&c使用方法: /libertybans addon <list|reload>'
+    reload-addon:
+      success: '&a拡張機能の&e%ADDON%&aを再読み込みしました。'
+      usage: '&c使用方法: /libertybans addon reload <addon> すべての拡張機能を再読み込みするには/libertybansを実行すればよい'
+      does-not-exist: '&cその拡張機能は存在しません。'
+      failed: '&c拡張機能設定の再読み込み中にエラーが発生しました。サーバーコンソールを確認してください。'
+
+    listing:
+      message: '&b&lインストール済み拡張機能'
+      layout: '&7- %ADDON%'
+
+
+  no-permission: '&c申し訳ありませんが、この操作はできません。'
+  ellipses: '&a...'
+  restarted: '&a再起動が完了しました'
+  reloaded: '&a再読み込みが完了しました'
+  importing:
+    failure: '&cインポートに失敗しました。詳細はサーバーコンソールを確認してください。'
+    started: '&7インポートを開始しました。詳細と進捗はサーバーコンソールを確認してください。'
+    complete: '&7インポートが完了しました。'
+    usage: '&c使用方法: /libertybans import <advancedban|litebans|vanilla|self>'
+     # To prevent mistakes, it is not allowed to import multiple times at once.
+    in-progress: '&cインポートはすでに進行中です。'
+
+  reload-failed: '&c設定の再読み込み中にエラーが発生しました。サーバーコンソールを確認してください。'
+


### PR DESCRIPTION
Added Japanese language file. 
The following comments are intended for future Japanese contributors who may modify this translation.

### この翻訳を修正する日本人の方へ

「意味がぶれない易しい表現」と「読みやすい日本語」を目指して翻訳しています。私も、英語と日本語、翻訳のプロではありませんので、改善点はいくつか見つかると思います。その場合は遠慮なく修正してください。

私が翻訳中に書いたメモを残して置きます。

### 翻訳の留意点

- 文脈から理解できるものは省く
- ログに残るものは正確性を重視する
- 厳密な表現のために「助詞+なる」は避ける
- 適切な動詞があれば「名詞＋する」の複合動詞は避ける
- 意訳と直訳のバランスを取る
- 過度な敬語は避けて丁寧語を用いる
- 安易に受け身表現を用いない
- 意味の切れ目に句点を用いる
- UI的な要素に句読点は用いない
- スペースを開けない
- カタカナで使われる一般的な英語は残す
    - この場合は「する」の動詞をつけてもよいとした
- コマンドのやまかっこ内は訳さない
    - 賛否両論あるかもしれないが、コマンド自体が翻訳不可なことにくわえて、基本的には管理者がつかうためのものであるため、やまかっこは訳さないことにした。
- エンドユーザーへ送信するものは正確な表現よりも伝わる表現を意識する

### 統一した表現

- usage = 使用方法
- scope = 範囲
    - スコープの方がいいかもしれない
- BAN = BAN（アクセス禁止）
    - ゲーマーには非常に浸透したワードだが、エンドユーザーへは念のため補足を入れる。
        - Minecraftでは「このサーバーへのアクセスは禁止されています」という表現が使われている。
- mute = ミュート（チャット禁止）
    - BANと同様
- warn = 警告
    - 忠告と迷ったが、諭す意味合いが強かったため警告と表現した。二度目はないぞ！
- kick = キック
    - アンパンマンはアンキックする
- un~ = 取り消す
    - 解除だと意味合いが異なる
- operator = 担当者
    - オペレーターは専門的だったり、ゲーム要素としてエンドユーザーの目に触れるものが多い
    - 操作者は一般的な用語ではない
- punishment type = 刑罰
    - 処罰は刑罰に処する行為を意味する。
    - 罰だと色んな意味を含む。
    - 刑罰が適切だが、刑罰はその種類まで含むため、「刑罰の種類」だと不適切
- reason = 理由
    - 条理の方が正しい意味合いな気もするが一般的な言葉ではないため
- date enacted = 執行日
    - 刑罰に処した日のため、施行日は不適切
- history = 前歴
    - 履歴だと時系列順に行動のすべてが記録される意味合いになる。
    - 警告を含めた履歴を指す場合は、前科ではなく前歴が適切
- not found = 見当たらない
    - 「見つからない」よりも「見当たらない」が適当
    - 「存在しない」だとnot existに近い
- subject = 主な内容
    - ban-listなどの列名に使われるが、主題や題目は適当ではない
- blame = 執行人
    - 刑罰に処したスタッフを指すため、責任者は不適切
- account = アカウント
- account-history = アカウント履歴
- recorded = 記録
- delete = 消去
    - 削除だと一部分のみなので消去
- timestamp = 時刻印
    - タイムスタンプは一般的な表現ではない
    - 時刻印も一般的ではないが、時刻+印でイメージはしやすい
    - 日立などの企業でも使われている名称
- Strong possibility = 可能性 高
- Mere Possibility = 可能性 低
- expired = 刑期満了
    - 釈放おめでとう
- Spamming = スパム行為
- Hacking = 不正行為
    - ハッキングでもいい気はする
    - 不正ツール使用でもいい気はするが、UIに書くには長い気もする
- console = コンソール
    - 管理者はこの用語がすぐわかるため直訳した。
- infinite = 無期限
    - もうやけくそになってきた
- never = 永久
- relative = 永久
- All servers = 全サーバー
- NameUnknown = 無名
- addon = 拡張機能
- import = インポート

### 特記事項

- カンマのないメッセージはUI要素かと思ったが、そんなこともなかったため、句点を書き足した。
- usageやfooterのページ番号に使われているカンマは、句点にせず取り除いた。
    - UI的な要素に句点の使用は適さない。
- 「Successfully deleted」を「消去が完了しました」と訳すと冗長なので「消去しました」と表現した。
- 「you may not ~」は、形式的な意味合いを持つ禁止表現ではあるが、エンドユーザー向けメッセージのためシンプルに「できません」と表現した。
    - 「you may not ~」は上から目線なニュアンスを持つと説明されることもあるが、正しくは、機械的、形式的な強い禁止表現であって、そこに感情的なニュアンスは含まれない。しかし、感情を全く含まない表現であるがゆえに、受け手側は冷たくされたような印象を受けるため、話し言葉として使うことは避けるべきである。
- 「alt account」は、中古アカウントとも呼ばれるが、意味合いが全く異なるため、「代替アカウント」と直訳した。
    - 代替アカウントとサブアカウントも明確に区別できる。代替アカウントは「捨て垢」という表現が近い。サブアカウントのように正しい目的のために使われることはほとんどなく、悪意を持った活動に利用されることが多い。専用販売サイトにて代替アカウントは取引されているが、アカウントの売買はMinecraftの規約で禁止されているため、その利用は違反行為に当たる。また、アカウントが売却されたものであるとは限らず、中にはハッキングによって強奪されたものまである。多数の人間によって使いまわされていることも多く、アカウントが誰のものなのかはっきりしないのが実情である。
- 「%USERNAME% (on %ADDRESS%) at %DATE_RECORDED% (%DATE_RECORDED_RAW%)」の「at」は「@」と表現した。
    - 「at」はその時点という意味になるが「時点」と書くと冗長な上に、このメッセージはすべて英数字表現であるため、漢字が二文字並ぶと違和感を覚える。
    - 「@」であればメールアドレスなどで馴染みがあるため、理解するための思考を挟むこともない。
- 「escalation track」は馴染みがなさすぎてわからない用語のため、そのまま「エスカレーション・トラック」と表現した。
    - エスカレーション自体はビジネス用語として使われるため、問題ないはず。
- /blameの実行で表示される「console」は、プレイヤー名がすべて英数字なので表記を統一するためにあえて訳さなかった。
- 後半は力尽きたから何も考えていない。

参考資料:

- 日本語練習帳 - 大野 晋 (著)
- 公用文作成の考え方: https://www.bunka.go.jp/seisaku/bunkashingikai/kokugo/hokoku/pdf/93651301_01.pdf