### PR TITLE
Fix webhook payload truncation at component variables

### DIFF
--- a/bans-core-addons/webhook/src/main/java/space/arim/libertybans/core/addon/webhook/PostWebhookListener.java
+++ b/bans-core-addons/webhook/src/main/java/space/arim/libertybans/core/addon/webhook/PostWebhookListener.java
@@ -108,7 +108,7 @@ public final class PostWebhookListener {
             }
         }
         var future = formatted.thenCompose(component -> {
-            String json = ((TextComponent) component).content();
+            String json = plainText(component);
             return postWebhook(webhookUrl, json);
         });
         futurePoster.postFuture(future);
@@ -129,5 +129,29 @@ public final class PostWebhookListener {
                 logger.warn("Received unexpected status code {} from webhook API", statusCode);
             }
         });
+    }
+
+    /*
+     * Substituting a component-valued variable such as %SILENCE% splits the payload across child
+     * components, leaving only the text before the first match on the root. Reading the root's
+     * content truncated the payload and sent invalid JSON, so walk the whole tree instead.
+     *
+     * Adventure's plain-text serializer cannot do this here. Adventure 4 calls it
+     * PlainComponentSerializer and Adventure 5 calls it PlainTextComponentSerializer, and both are
+     * supported at runtime, so neither can be compiled against.
+     */
+    static String plainText(Component component) {
+        StringBuilder builder = new StringBuilder();
+        appendPlainText(component, builder);
+        return builder.toString();
+    }
+
+    private static void appendPlainText(Component component, StringBuilder builder) {
+        if (component instanceof TextComponent textComponent) {
+            builder.append(textComponent.content());
+        }
+        for (Component child : component.children()) {
+            appendPlainText(child, builder);
+        }
     }
 }

--- a/bans-core-addons/webhook/src/test/java/space/arim/libertybans/core/addon/webhook/PlainTextTest.java
+++ b/bans-core-addons/webhook/src/test/java/space/arim/libertybans/core/addon/webhook/PlainTextTest.java
@@ -1,0 +1,57 @@
+/*
+ * LibertyBans
+ * Copyright © 2026 Anand Beh
+ *
+ * LibertyBans is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * LibertyBans is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with LibertyBans. If not, see <https://www.gnu.org/licenses/>
+ * and navigate to version 3 of the GNU Affero General Public License.
+ */
+
+package space.arim.libertybans.core.addon.webhook;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlainTextTest {
+
+    @Test
+    public void keepsTextAfterAComponentSubstitution() {
+        String payload = "{\"content\":\"x%SILENCE%y\"}";
+
+        Component component = Component.text(payload).replaceText((config) -> config
+                .matchLiteral("%SILENCE%")
+                .replacement(Component.text("[silent]")));
+
+        assertEquals("{\"content\":\"x[silent]y\"}", PostWebhookListener.plainText(component));
+    }
+
+    @Test
+    public void keepsTextAfterSeveralSubstitutions() {
+        String payload = "{\"a\":\"%SILENCE%\",\"b\":\"z\"}";
+
+        Component component = Component.text(payload)
+                .replaceText((config) -> config.matchLiteral("%SILENCE%").replacement(Component.text("s")))
+                .replaceText((config) -> config.matchLiteral("%HAS_EXPIRED%").replacement(Component.text("e")));
+
+        assertEquals("{\"a\":\"s\",\"b\":\"z\"}", PostWebhookListener.plainText(component));
+    }
+
+    @Test
+    public void leavesAPayloadWithoutVariablesUnchanged() {
+        String payload = "{\"content\":\"plain\"}";
+
+        assertEquals(payload, PostWebhookListener.plainText(Component.text(payload)));
+    }
+}


### PR DESCRIPTION
### Problem

The webhook addon reads the rendered payload with `((TextComponent) component).content()`, which returns only the root component's own text. A component-valued variable such as `%SILENCE%` or `%HAS_EXPIRED%` is substituted with `Component.replaceText`, and that call splits the payload. The text before the first match stays on the root, and everything after it moves into child components. The endpoint then receives only the part before the first component variable, which in practice is invalid JSON. This is the bug part of #381, which you separated from the feature request.

### Fix

`plainText` walks the component tree and appends the text of every node, so the whole payload is posted no matter how many substitutions happened. It replaces the cast and `content()` call at the end of `onEvent`.

Adventure's plain-text serializer would be the natural tool, but it cannot be used here. Adventure 4 names it `PlainComponentSerializer` and Adventure 5 names it `PlainTextComponentSerializer`, and both are supported at runtime. This build compiles against Adventure 4.7.0, and Paper 26.2 ships Adventure 5.2.0, so code compiled against either name fails on the other. That is also why `FormatterTest` can call `PlainComponentSerializer.plain()` while main code cannot. The traversal uses `Component#children` and `TextComponent#content`, which are unchanged between the two versions.

### Testing

Unit tests: `./mvnw -pl bans-core-addons/webhook -am package` passes, 577 tests in bans-core plus the 3 added in `PlainTextTest`. I ran it offline with `-P-docker-enabled -Dinvoker.skip=true` to avoid starting the Docker containers. The new tests cover a payload with one substitution, a payload with several substitutions, and a payload with no variables.

Live test on Paper 26.2 build 123, offline mode, HSQLDB, Java 25. The webhook addon posted to a local HTTP endpoint, `json-payload` was set to `{"content":"start silence=%SILENCE% victim=%VICTIM% END_OF_PAYLOAD","embeds":[{"title":"TAIL_EMBED","description":"%REASON%"}]}`, and `/libertybans ipban 203.0.113.203 -s fixed-repro` was run from the console. The receiving endpoint logged each body and whether it parsed as JSON.

Before the change:

```
body:   {"content":"start silence=
parsed: no, Unterminated string starting at: line 1 column 12 (char 11)
```

After the change:

```
body:   {"content":"start silence= [Silent] victim=203.0.113.203 END_OF_PAYLOAD","embeds":[{"title":"TAIL_EMBED","description":"fixed-repro"}]}
parsed: yes
```

The before run used the same build with only this line reverted, so nothing else differs between the two.

Not tested: platforms other than Paper, and a real Discord endpoint. `%HAS_EXPIRED%` is covered only by the unit test for repeated substitutions.

### Notes

This addresses the bug from #381 only. The feature half of that issue, a plain placeholder that evaluates to true or false for machine-readable relays, is not included.
